### PR TITLE
HACK: retry sendmsg/recvmsg on EAGAIN.

### DIFF
--- a/audioipc/src/msg.rs
+++ b/audioipc/src/msg.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::mem;
 use std::ptr;
 use std::os::unix::io::RawFd;
+use std;
 
 // Note: The following fields must be laid out together, the OS expects them
 // to be part of a single allocation.
@@ -10,6 +11,17 @@ use std::os::unix::io::RawFd;
 struct CmsgSpace {
     cmsghdr: libc::cmsghdr,
     data: libc::c_int,
+}
+
+unsafe fn sendmsg_retry(fd: libc::c_int, msg: *const libc::msghdr, flags: libc::c_int) -> libc::ssize_t {
+    loop {
+        let r = libc::sendmsg(fd, msg, flags);
+        if r == -1 && io::Error::last_os_error().raw_os_error().unwrap() == libc::EAGAIN {
+            std::thread::yield_now();
+            continue;
+        }
+        return r;
+    }
 }
 
 pub fn sendmsg(fd: RawFd, to_send: &[u8], fd_to_send: Option<RawFd>) -> io::Result<usize> {
@@ -38,11 +50,22 @@ pub fn sendmsg(fd: RawFd, to_send: &[u8], fd_to_send: Option<RawFd>) -> io::Resu
 
     cmsg.data = fd_to_send.unwrap_or(-1);
 
-    let result = unsafe { libc::sendmsg(fd, &msghdr, 0) };
+    let result = unsafe { sendmsg_retry(fd, &msghdr, 0) };
     if result >= 0 {
         Ok(result as usize)
     } else {
         Err(io::Error::last_os_error())
+    }
+}
+
+unsafe fn recvmsg_retry(fd: libc::c_int, msg: *mut libc::msghdr, flags: libc::c_int) -> libc::ssize_t {
+    loop {
+        let r = libc::recvmsg(fd, msg, flags);
+        if r == -1 && io::Error::last_os_error().raw_os_error().unwrap() == libc::EAGAIN {
+            std::thread::yield_now();
+            continue;
+        }
+        return r;
     }
 }
 
@@ -64,7 +87,7 @@ pub fn recvmsg(fd: RawFd, to_recv: &mut [u8]) -> io::Result<(usize, Option<RawFd
     };
     iovec.iov_len = to_recv.len();
 
-    let result = unsafe { libc::recvmsg(fd, &mut msghdr, 0) };
+    let result = unsafe { recvmsg_retry(fd, &mut msghdr, 0) };
     if result >= 0 {
         let fd = if msghdr.msg_controllen == mem::size_of::<CmsgSpace>() as _ &&
             cmsg.cmsghdr.cmsg_len == mem::size_of::<CmsgSpace>() as _ &&


### PR DESCRIPTION
This is the wrong approach since it wastes resources spinning on an fd, but it's sufficient to get IPC working within Gecko until a complete fix where the server pays attention to the poll status of the fds is ready.

I'm working on a proper fix, which I'll submit once it's ready.  It'll render this hack obsolete (i.e. it won't trigger and becomes harmless), at which point we can remove it.