### PR TITLE
Simple first pass at shared memory for data_callback

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -17,3 +17,4 @@ libc = "0.2"
 mio = "0.6.7"
 cubeb-core = { git = "https://github.com/djg/cubeb-rs", version="^0.1" }
 byteorder = "1"
+memmap = "0.5.2"

--- a/audioipc/src/connection.rs
+++ b/audioipc/src/connection.rs
@@ -110,22 +110,17 @@ impl Connection {
     where
         ST: Serialize + Debug,
     {
-        self.send_with_fd(msg, None)
+        self.send_with_fd::<ST, Connection>(msg, None)
     }
 
-    pub fn send_with_fd<ST, FD>(&mut self, msg: ST, fd_to_send: FD) -> Result<usize>
+    pub fn send_with_fd<ST, FD>(&mut self, msg: ST, fd_to_send: Option<FD>) -> Result<usize>
     where
         ST: Serialize + Debug,
-        FD: Into<Option<Connection>>,
+        FD: IntoRawFd + Debug,
     {
         let encoded: Vec<u8> = serialize(&msg, bincode::Infinite)?;
-        // TODO: Switch back to send_fd.
-        // TODO: Pass fd with StreamCreated message, not separately OOB.
-        // let msg = vec![0; 0];
-        let fd = fd_to_send.into();
-        info!("send_with_fd {:?}, {:?}", msg, fd);
-        // super::send_fd(&mut stream.stream, &msg, remote_fd.into_raw_fd()).unwrap();
-        self.stream.send_fd(&encoded, fd).chain_err(
+        info!("send_with_fd {:?}, {:?}", msg, fd_to_send);
+        self.stream.send_fd(&encoded, fd_to_send).chain_err(
             || "Failed to send message with fd"
         )
     }

--- a/audioipc/src/lib.rs
+++ b/audioipc/src/lib.rs
@@ -23,18 +23,29 @@ extern crate cubeb_core;
 extern crate libc;
 extern crate byteorder;
 
+extern crate memmap;
+
 mod connection;
 pub mod errors;
 pub mod messages;
 mod msg;
+pub mod shm;
 
 pub use connection::*;
 pub use messages::{ClientMessage, ServerMessage};
 use std::env::temp_dir;
 use std::path::PathBuf;
 
-pub fn get_uds_path() -> PathBuf {
+fn get_temp_path(name: &str) -> PathBuf {
     let mut path = temp_dir();
-    path.push("cubeb-sock");
+    path.push(name);
     path
+}
+
+pub fn get_uds_path() -> PathBuf {
+    get_temp_path("cubeb-sock")
+}
+
+pub fn get_shm_path(dir: &str) -> PathBuf {
+    get_temp_path(&format!("cubeb-shm-{}", dir))
 }

--- a/audioipc/src/messages.rs
+++ b/audioipc/src/messages.rs
@@ -209,7 +209,7 @@ pub enum ServerMessage {
     StreamSetPanning(usize, f32),
     StreamGetCurrentDevice(usize),
 
-    StreamDataCallback(Vec<u8>)
+    StreamDataCallback(isize)
 }
 
 // Server -> Client messages.
@@ -227,6 +227,8 @@ pub enum ClientMessage {
     ContextEnumeratedDevices(Vec<DeviceInfo>),
 
     StreamCreated(usize), /*(RawFd)*/
+    StreamCreatedInputShm, /*(RawFd)*/
+    StreamCreatedOutputShm, /*(RawFd)*/
     StreamDestroyed,
 
     StreamStarted,
@@ -238,7 +240,7 @@ pub enum ClientMessage {
     StreamPanningSet,
     StreamCurrentDevice(Device),
 
-    StreamDataCallback(Vec<u8>, isize, usize),
+    StreamDataCallback(isize, usize),
     StreamStateCallback(ffi::cubeb_state),
 
     ContextError(ffi::cubeb_error_code),

--- a/audioipc/src/shm.rs
+++ b/audioipc/src/shm.rs
@@ -1,0 +1,133 @@
+use std::path::Path;
+use std::fs::{remove_file, OpenOptions, File};
+use std::sync::atomic;
+use memmap::{Mmap, Protection};
+use errors::*;
+
+pub struct SharedMemReader {
+    mmap: Mmap,
+}
+
+impl SharedMemReader {
+    pub fn new(path: &Path, size: usize) -> Result<(SharedMemReader, File)> {
+        let file = OpenOptions::new().read(true)
+                                     .write(true)
+                                     .create_new(true)
+                                     .open(path)?;
+        let _ = remove_file(path);
+        file.set_len(size as u64)?;
+        let mmap = Mmap::open(&file, Protection::Read)?;
+        assert_eq!(mmap.len(), size);
+        Ok((SharedMemReader {
+            mmap
+        }, file))
+    }
+
+    pub fn read(&self, buf: &mut [u8]) -> Result<()> {
+        if buf.is_empty() {
+            return Ok(());
+        }
+        // TODO: Track how much is in the shm area.
+        if buf.len() <= self.mmap.len() {
+            atomic::fence(atomic::Ordering::Acquire);
+            unsafe {
+                let len = buf.len();
+                buf.copy_from_slice(&self.mmap.as_slice()[..len]);
+            }
+            Ok(())
+        } else {
+            bail!("mmap size");
+        }
+    }
+}
+
+pub struct SharedMemSlice {
+    mmap: Mmap,
+}
+
+impl SharedMemSlice {
+    pub fn from(file: File, size: usize) -> Result<SharedMemSlice> {
+        let mmap = Mmap::open(&file, Protection::Read)?;
+        assert_eq!(mmap.len(), size);
+        Ok(SharedMemSlice {
+            mmap
+        })
+    }
+
+    pub fn get_slice(&self, size: usize) -> Result<&[u8]> {
+        if size == 0 {
+            return Ok(&[]);
+        }
+        // TODO: Track how much is in the shm area.
+        if size <= self.mmap.len() {
+            atomic::fence(atomic::Ordering::Acquire);
+            let buf = unsafe { &self.mmap.as_slice()[..size] };
+            Ok(buf)
+        } else {
+            bail!("mmap size");
+        }
+    }
+}
+
+pub struct SharedMemWriter {
+    mmap: Mmap,
+}
+
+impl SharedMemWriter {
+    pub fn new(path: &Path, size: usize) -> Result<(SharedMemWriter, File)> {
+        let file = OpenOptions::new().read(true)
+                                     .write(true)
+                                     .create_new(true)
+                                     .open(path)?;
+        let _ = remove_file(path);
+        file.set_len(size as u64)?;
+        let mmap = Mmap::open(&file, Protection::ReadWrite)?;
+        Ok((SharedMemWriter {
+            mmap
+        }, file))
+    }
+
+    pub fn write(&mut self, buf: &[u8]) -> Result<()> {
+        if buf.is_empty() {
+            return Ok(());
+        }
+        // TODO: Track how much is in the shm area.
+        if buf.len() <= self.mmap.len() {
+            unsafe {
+                self.mmap.as_mut_slice()[..buf.len()].copy_from_slice(buf);
+            }
+            atomic::fence(atomic::Ordering::Release);
+            Ok(())
+        } else {
+            bail!("mmap size");
+        }
+    }
+}
+
+pub struct SharedMemMutSlice {
+    mmap: Mmap,
+}
+
+impl SharedMemMutSlice {
+    pub fn from(file: File, size: usize) -> Result<SharedMemMutSlice> {
+        let mmap = Mmap::open(&file, Protection::ReadWrite)?;
+        assert_eq!(mmap.len(), size);
+        Ok(SharedMemMutSlice {
+            mmap
+        })
+    }
+
+    pub fn get_mut_slice(&mut self, size: usize) -> Result<&mut [u8]> {
+        if size == 0 {
+            return Ok(&mut []);
+        }
+        // TODO: Track how much is in the shm area.
+        if size <= self.mmap.len() {
+            let buf = unsafe { &mut self.mmap.as_mut_slice()[..size] };
+            atomic::fence(atomic::Ordering::Release);
+            Ok(buf)
+        } else {
+            bail!("mmap size");
+        }
+    }
+}


### PR DESCRIPTION
 Add a simple shared memory wrapper and replace Vec copies across socket with shm updates.

When a client connects, the server creates two files to be used shared memory mappings, immediately deletes them (retaining the fds), then mmap()s the fds.  The retained fds are then sent to the client to be mmap()ed into the client's address space.