### PR TITLE
Create cubeb::Context on demand.

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,7 +6,7 @@ description = "Remote cubeb server"
 
 [dependencies]
 audioipc = { path = "../audioipc" }
-cubeb = { git = "https://github.com/djg/cubeb-rs", version="^0.2" }
+cubeb = { git = "https://github.com/djg/cubeb-rs", version="^0.3" }
 cubeb-core = { git = "https://github.com/djg/cubeb-rs", version="^0.1" }
 error-chain = "0.10.0"
 lazycell = "^0.4"


### PR DESCRIPTION
Create cubeb context on first connection to server. This delays creation of cubeb context until it's going to be required. If Context creation fails, all commands return error instead of causing a panic!