### PR TITLE
Revert the reentrancy hacks for max_channel_count and get_backend_id.

### DIFF
--- a/client/src/context.rs
+++ b/client/src/context.rs
@@ -52,18 +52,14 @@ impl Context for ClientContext {
     }
 
     fn backend_id(&self) -> &'static CStr {
-        // HACK: This is called reentrantly from Gecko's AudioStream::DataCallback.
-        //assert_not_in_callback();
+        assert_not_in_callback();
         unsafe { CStr::from_ptr(b"remote\0".as_ptr() as *const _) }
     }
 
     fn max_channel_count(&self) -> Result<u32> {
-        // HACK: This needs to be reentrant as MSG calls it from within data_callback.
-        //assert_not_in_callback();
-        //let mut conn = self.connection();
-        //send_recv!(conn, ContextGetMaxChannelCount => ContextMaxChannelCount())
-        warn!("Context::max_channel_count lying about result until reentrancy issues resolved.");
-        Ok(2)
+        assert_not_in_callback();
+        let mut conn = self.connection();
+        send_recv!(conn, ContextGetMaxChannelCount => ContextMaxChannelCount())
     }
 
     fn min_latency(&self, params: &StreamParams) -> Result<u32> {


### PR DESCRIPTION
BMO bugs 1403041 and 1403043 have fixes for this, so we can revert the hacks in the remoting code.

The fixes haven't landed yet, so we'll need to sequence merging this/updating the Gecko import with the patches in those bugs landing.