### PR TITLE
Use a unique UDS path when running inside Gecko

### DIFF
--- a/audioipc/src/lib.rs
+++ b/audioipc/src/lib.rs
@@ -122,8 +122,8 @@ fn get_temp_path(name: &str) -> PathBuf {
     path
 }
 
-pub fn get_uds_path() -> PathBuf {
-    get_temp_path("cubeb-sock")
+pub fn get_uds_path(id: u64) -> PathBuf {
+    get_temp_path(&format!("cubeb-sock-{}", id))
 }
 
 pub fn get_shm_path(dir: &str) -> PathBuf {

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,4 +8,5 @@ description = "Cubeb Backend for talking to remote cubeb server."
 audioipc = { path="../audioipc" }
 cubeb-backend = { git="https://github.com/djg/cubeb-rs", version="^0.2" }
 cubeb-core = { git="https://github.com/djg/cubeb-rs", version="^0.1" }
+libc = "0.2"
 log = "^0.3.6"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -7,6 +7,7 @@ extern crate audioipc;
 extern crate cubeb_core;
 #[macro_use]
 extern crate cubeb_backend;
+extern crate libc;
 #[macro_use]
 extern crate log;
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,6 +11,7 @@ cubeb = { git = "https://github.com/djg/cubeb-rs", version="^0.3" }
 bytes = "0.4"
 error-chain = "0.10.0"
 lazycell = "^0.4"
+libc = "0.2"
 log = "^0.3.6"
 mio = "0.6.7"
 mio-uds = "0.6.4"


### PR DESCRIPTION
This addresses BMO bug 1407490.  Make get_uds_path take an id argument and pass the server PID.  This allows separate servers for each running Gecko process as a temporary fix until BMO bug 1405877 is addressed.