### PR TITLE
audioipc: Update to bincode 1.3 again.

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -10,7 +10,7 @@ description = "Remote Cubeb IPC"
 edition = "2018"
 
 [dependencies]
-bincode = "1"
+bincode = "1.3"
 bytes = "0.4"
 cubeb = "0.9"
 futures = "0.1.29"

--- a/audioipc/src/codec.rs
+++ b/audioipc/src/codec.rs
@@ -5,7 +5,7 @@
 
 //! `Encoder`s and `Decoder`s from items to/from `BytesMut` buffers.
 
-use bincode::{self, deserialize, serialized_size};
+use bincode::{self, Options};
 use bytes::{BufMut, ByteOrder, BytesMut, LittleEndian};
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
@@ -104,10 +104,12 @@ impl<In, Out> LengthDelimitedCodec<In, Out> {
         let buf = buf.split_to(n).freeze();
 
         trace!("Attempting to decode");
-        let msg = deserialize::<Out>(buf.as_ref()).map_err(|e| match *e {
-            bincode::ErrorKind::Io(e) => e,
-            _ => io::Error::new(io::ErrorKind::Other, *e),
-        })?;
+        let msg = bincode::options()
+            .deserialize::<Out>(buf.as_ref())
+            .map_err(|e| match *e {
+                bincode::ErrorKind::Io(e) => e,
+                _ => io::Error::new(io::ErrorKind::Other, *e),
+            })?;
 
         trace!("... Decoded {:?}", msg);
         Ok(Some(msg))
@@ -157,7 +159,7 @@ where
 
     fn encode(&mut self, item: Self::In, buf: &mut BytesMut) -> io::Result<()> {
         trace!("Attempting to encode");
-        let encoded_len = serialized_size(&item).unwrap();
+        let encoded_len = bincode::options().serialized_size(&item).unwrap();
         if encoded_len > MAX_MESSAGE_LEN {
             trace!("oversized message {}", encoded_len);
             return Err(io::Error::new(
@@ -170,9 +172,8 @@ where
 
         buf.put_u32_le(encoded_len as u32);
 
-        #[allow(deprecated)]
-        if let Err(e) = bincode::config()
-            .limit(encoded_len)
+        if let Err(e) = bincode::options()
+            .with_limit(encoded_len)
             .serialize_into::<_, Self::In>(&mut buf.writer(), &item)
         {
             match *e {


### PR DESCRIPTION
This was attempted in https://github.com/mozilla/audioipc-2/commit/b0f2a7a9325a8866be13875260df2dceb1de2388, but reverted due to both local breakage and issues landing bincode 1.3 in Gecko ([BMO 1675534](https://bugzilla.mozilla.org/show_bug.cgi?id=1675534)).

For backwards compat reasons, bincode's standalone `serialize`, `deserialize`, and `serialized_size` functions use a different set of options to the default returned by `bincode::options`.  codec.rs used the bare `deserialize` but called `serialize` via `bincode::options`, resulting in an incompatible serialization between encode and decode.

Leaving this PR as a draft, since may still be other issues blocking bincode 1.3 in Gecko.