### PR TITLE
server: Clean up ServerStream if stream_init fails.

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -777,7 +777,11 @@ impl CubebServer {
             );
             match stream {
                 Ok(stream) => stream,
-                Err(e) => return Err(e.into()), // XXX full teardown of ServerStream?
+                Err(e) => {
+                    debug!("Unregistering stream {:?} (stream error {:?})", stm_tok, e);
+                    self.streams.remove(stm_tok);
+                    return Err(e.into());
+                }
             }
         };
 


### PR DESCRIPTION
If `stream_init` fails, there is a partially initialized `ServerStream` left behind in the `CubebServer`'s stream slab.  Since this will never be used again, we need to remove it explicitly rather than relying on a `stream_destroy`.

Follow up to e925e82ca9887af9b04d92a5e304b5df94942c79.  I had noted this with a comment, but forgot to fix it before finishing e925e82ca9887af9b04d92a5e304b5df94942c79.