### PR TITLE
audioipc: Add support for ashmem to shm.rs.

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -35,6 +35,9 @@ miow = "0.3.3"
 mio-named-pipes = { git = "https://github.com/kinetiknz/mio-named-pipes", rev = "21c26326f5f45f415c49eac4ba5bc41a2f961321" }
 winapi = { version = "0.3.6", features = ["combaseapi", "objbase"] }
 
+[target.'cfg(target_os = "android")'.dependencies]
+ashmem = { git = "https://github.com/kinetiknz/ashmem-rs", rev = "e47f470a54193532d60057ec54f864e06aeaff36" }
+
 [dependencies.error-chain]
 version = "0.11.0"
 default-features = false

--- a/audioipc/src/shm.rs
+++ b/audioipc/src/shm.rs
@@ -46,11 +46,35 @@ impl SharedMemView {
 mod unix {
     use super::*;
     use memmap::{MmapMut, MmapOptions};
-    use std::env::temp_dir;
-    use std::fs::{remove_file, File, OpenOptions};
+    use std::fs::File;
     use std::os::unix::io::FromRawFd;
 
-    fn open_shm_file(id: &str) -> Result<File> {
+    #[cfg(target_os = "android")]
+    fn open_shm_file(_id: &str, size: usize) -> Result<File> {
+        unsafe {
+            let fd = ashmem::ASharedMemory_create(std::ptr::null(), size);
+            if fd >= 0 {
+                // Drop PROT_EXEC
+                let r = ashmem::ASharedMemory_setProt(fd, libc::PROT_READ | libc::PROT_WRITE);
+                assert_eq!(r, 0);
+                return Ok(File::from_raw_fd(fd.try_into().unwrap()));
+            }
+            Err(std::io::Error::last_os_error().into())
+        }
+    }
+
+    #[cfg(not(target_os = "android"))]
+    fn open_shm_file(id: &str, size: usize) -> Result<File> {
+        let file = open_shm_file_impl(id)?;
+        allocate_file(&file, size)?;
+        Ok(file)
+    }
+
+    #[cfg(not(target_os = "android"))]
+    fn open_shm_file_impl(id: &str) -> Result<File> {
+        use std::env::temp_dir;
+        use std::fs::{remove_file, OpenOptions};
+
         let id_cstring = std::ffi::CString::new(id).unwrap();
 
         #[cfg(target_os = "linux")]
@@ -101,6 +125,7 @@ mod unix {
         Ok(file)
     }
 
+    #[cfg(not(target_os = "android"))]
     fn handle_enospc(s: &str) -> Result<()> {
         let err = std::io::Error::last_os_error();
         let errno = err.raw_os_error().unwrap_or(0);
@@ -112,6 +137,7 @@ mod unix {
         Ok(())
     }
 
+    #[cfg(not(target_os = "android"))]
     fn allocate_file(file: &File, size: usize) -> Result<()> {
         use std::os::unix::io::AsRawFd;
 
@@ -170,8 +196,7 @@ mod unix {
 
     impl SharedMem {
         pub fn new(id: &str, size: usize) -> Result<(SharedMem, PlatformHandle)> {
-            let file = open_shm_file(id)?;
-            allocate_file(&file, size)?;
+            let file = open_shm_file(id, size)?;
             let mut mmap = unsafe { MmapOptions::new().map_mut(&file)? };
             assert_eq!(mmap.len(), size);
             let view = SharedMemView {


### PR DESCRIPTION
Add support for Android's [ASharedMemory](https://developer.android.com/ndk/reference/group/memory) to shm.rs.