### PR TITLE
Replace dependency to memmap with memmap2

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2"
 mio = "0.6.19"
 mio-uds = "0.6.7"
 tokio-reactor = "0.1"
-memmap = "0.7"
+memmap2 = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 mio = "0.6.19"

--- a/audioipc/src/shm.rs
+++ b/audioipc/src/shm.rs
@@ -45,7 +45,7 @@ impl SharedMemView {
 #[cfg(unix)]
 mod unix {
     use super::*;
-    use memmap::{MmapMut, MmapOptions};
+    use memmap2::{MmapMut, MmapOptions};
     use std::fs::File;
     use std::os::unix::io::FromRawFd;
 


### PR DESCRIPTION
The crate [memmap](https://crates.io/crates/memmap) has been marked unmaintained, see the [advisory](https://rustsec.org/advisories/RUSTSEC-2020-0077).

This PR replaces the dependency with [memmap2](https://crates.io/crates/memmap2), which is a maintained fork of memmap.