### PR TITLE
Rework IPC messaging core

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,31 @@
+This replaces the existing IPC messaging core built around tokio 0.1 with a new one built around mio 0.7.
+
+The intention of this change is to reduce external dependencies and tighten control over the architecture so that it can be customized for better soft-RT performance for our audio uses.  This will also make it easier to introduce Firefox profiler markers in the IPC code to improve field debugability.
+
+Replacing the old 0.1 IPC core also addresses the various issues that were blocking AudioIPC for macOS in Gecko.
+
+The initial version retains a similar general architecture to the existing IPC code in terms of threading and relationships between server, client, cubeb context and cubeb stream.  With the initial working version in place, the intention is to then take advantage of the new architecture to enable functionality that wasn't easy to provide within the restrictions of the old architecture, including:
+    - per-stream callback remoting for high priority/low latency streams
+        where each stream may be serviced by it's own thread/EventLoop on the client side
+    - more efficient use of shared memory segments, including using shmem for message passing
+    - client-side stream multiplexing for low priority/high latency streams
+        trading off latency for reduced IPC overhead
+    - providing a new API for cubeb stream consumers allowing them to provide their own thread for callback processing,
+      with new methods to wait for free buffer space and provide refilled buffers for capture/playback
+
+General architecture:
+- Server side:
+    - Main "server" thread executing EventLoop, with one connection per client
+        - Connections are Unix Domain Sockets on Unix, and Named Pipes on Windows
+        - Each connection services one or more remote cubeb streams for the client
+    - RPC Proxy, allowing thread-safe message send/receive, used within
+        cubeb callbacks to communicate with client-side cubeb streams via EventLoop
+- Client side:
+    - EventLoop thread with a single connection, communicating with server
+    - RPC Proxy per cubeb stream, remoting cubeb API calls to the server (via EventLoop)
+
+TODO:
+- Remove existing tokio 0.1 code and deps (once all platforms switched over)
+- Delete tokio_named_pipes, tokio_uds_stream
+- Delete meesagestream_*.rs
+- Delete AsyncSendMsg/AsyncRecvMsg traits/impls

--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 bincode = "1"
-bytes = "0.4"
+bytes = "0.4" # XXX update to 1.0
 cubeb = "0.9"
 futures = "0.1.29"
 log = "0.4"
@@ -20,6 +20,9 @@ serde_derive = "1"
 tokio = "0.1"
 tokio-io = "0.1"
 audio_thread_priority = "0.23.4"
+# XXX: IPC core rework.
+mio-07 = { package = "mio", version = "0.7",  features = ["os-poll", "net", "os-ext"] }
+slab = "0.4"
 
 [target.'cfg(unix)'.dependencies]
 iovec = "0.1"

--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -1,0 +1,592 @@
+// Copyright © 2021 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details
+
+use std::io::Result;
+use std::sync::{mpsc, Arc};
+
+use mio_07::{event::Event, Events, Interest, Poll, Registry, Token, Waker};
+use slab::Slab;
+
+use crate::messages::AssocRawPlatformHandle;
+use crate::rpccore::{make_client, make_server, Handler, Proxy, RpcClient, RpcServer};
+use crate::{
+    codec::Codec,
+    codec::LengthDelimitedCodec,
+    sys::{self, RecvMsg, SendMsg},
+    ClientMessage, PlatformHandle, ServerMessage,
+};
+
+use serde::{de::DeserializeOwned, Serialize};
+use std::fmt::Debug;
+
+#[cfg(unix)]
+use crate::cmsg;
+#[cfg(windows)]
+use crate::duplicate_platform_handle;
+
+const WAKE_TOKEN: Token = Token(!0);
+
+// Requests sent by an EventLoopHandle to be serviced by
+// the handle's associated EventLoop.
+enum Request {
+    // See EventLoop::add_connection
+    AddConnection(
+        sys::Pipe,
+        Box<dyn Driver + Send>,
+        mpsc::Sender<Result<Token>>,
+    ),
+    // See EventLoop::shutdown
+    Shutdown,
+    // See EventLoop::wake_connection
+    WakeConnection(Token),
+}
+
+// EventLoopHandle is a cloneable external reference
+// to a running EventLoop, allowing registration of
+// new client and server connections, in addition to
+// requesting the EventLoop shut down cleanly.
+#[derive(Clone)]
+pub struct EventLoopHandle {
+    waker: Arc<Waker>,
+    requests_tx: mpsc::Sender<Request>,
+}
+
+impl EventLoopHandle {
+    pub fn new_client<C: RpcClient + 'static>(
+        &self,
+        server_pipe: sys::Pipe,
+    ) -> Result<Proxy<<C as RpcClient>::Request, <C as RpcClient>::Response>>
+    where
+        <C as RpcClient>::Request: Serialize + Debug + AssocRawPlatformHandle + Send,
+        <C as RpcClient>::Response: DeserializeOwned + Debug + AssocRawPlatformHandle + Send,
+    {
+        let (handler, mut proxy) = make_client::<C>();
+        let driver = Box::new(FramedDriver::new(handler));
+        let token = self.add_connection(server_pipe, driver)?;
+        proxy.connect_event_loop(self.clone(), token);
+        Ok(proxy)
+    }
+
+    pub fn new_server<S: RpcServer + Send + 'static>(&self, server: S) -> Result<PlatformHandle>
+    where
+        <S as RpcServer>::Request: DeserializeOwned + Debug + AssocRawPlatformHandle + Send,
+        <S as RpcServer>::Response: Serialize + Debug + AssocRawPlatformHandle + Send,
+    {
+        let handler = make_server::<S>(server);
+        let driver = Box::new(FramedDriver::new(handler));
+        let (server_pipe, client_pipe) = sys::make_pipe_pair()?;
+        self.add_connection(server_pipe, driver)?;
+        Ok(client_pipe)
+    }
+
+    // Register a new connection with associated driver on the EventLoop.
+    // TODO: Since this is called from a Gecko main thread, make this non-blocking wrt. the EventLoop.
+    fn add_connection(
+        &self,
+        connection: sys::Pipe,
+        driver: Box<dyn Driver + Send>,
+    ) -> Result<Token> {
+        let (tx, rx) = mpsc::channel();
+        self.requests_tx
+            .send(Request::AddConnection(connection, driver, tx))
+            .expect("EventLoop::add_connection");
+        self.waker.wake().expect("wake failed");
+        let token = rx.recv().expect("EventLoop::add_connection")?;
+        Ok(token)
+    }
+
+    // Signal EventLoop to shutdown.  Causes EventLoop::poll to return Ok(false).
+    pub fn shutdown(&self) {
+        self.requests_tx
+            .send(Request::Shutdown)
+            .expect("EventLoop::shutdown");
+        self.waker.wake().expect("wake failed");
+    }
+
+    // Signal EventLoop to wake connection specified by `token` for processing.
+    pub fn wake_connection(&self, token: Token) {
+        self.requests_tx
+            .send(Request::WakeConnection(token))
+            .expect("EventLoop::shutdown");
+        self.waker.wake().expect("wake failed");
+    }
+}
+
+// EventLoop owns all registered connections, and is responsible for calling each connection's
+// `handle_event` function any time a readiness or wake event associated with that connection is
+// produced.
+struct EventLoop {
+    poll: Poll,
+    events: Events,
+    waker: Arc<Waker>,
+    connections: Slab<Connection>,
+    requests: mpsc::Receiver<Request>,
+    requests_tx: mpsc::Sender<Request>,
+}
+
+const EVENT_LOOP_INITIAL_CLIENTS: usize = 64; // Initial client allocation, exceeding this will cause the connection slab to grow.
+const EVENT_LOOP_EVENTS_PER_ITERATION: usize = 256; // Number of events per poll() step, arbitrary limit.
+
+impl EventLoop {
+    fn new() -> Result<EventLoop> {
+        let poll = Poll::new()?;
+        let waker = Arc::new(Waker::new(poll.registry(), WAKE_TOKEN)?);
+        let (tx, rx) = mpsc::channel();
+        let eventloop = EventLoop {
+            poll,
+            events: Events::with_capacity(EVENT_LOOP_EVENTS_PER_ITERATION),
+            waker,
+            connections: Slab::with_capacity(EVENT_LOOP_INITIAL_CLIENTS),
+            requests: rx,
+            requests_tx: tx,
+        };
+
+        Ok(eventloop)
+    }
+
+    // Return a cloneable handle for controlling the EventLoop externally.
+    fn handle(&mut self) -> EventLoopHandle {
+        EventLoopHandle {
+            waker: self.waker.clone(),
+            requests_tx: self.requests_tx.clone(),
+        }
+    }
+
+    // Register a connection and driver.
+    fn add_connection(
+        &mut self,
+        connection: sys::Pipe,
+        driver: Box<dyn Driver + Send>,
+    ) -> Result<Token> {
+        if self.connections.len() == self.connections.capacity() {
+            trace!("connection slab full, insert will allocate");
+        }
+        let entry = self.connections.vacant_entry();
+        let token = Token(entry.key());
+        let connection = Connection::new(connection, token, driver, self.poll.registry())?;
+        debug!("[{:?}]: new connection", token);
+        entry.insert(connection);
+        Ok(token)
+    }
+
+    // Step EventLoop once.  Call this in a loop from a dedicated thread.
+    // Returns false if EventLoop is shutting down.
+    // Each step may call `handle_event` on any registered connection that
+    // has received readiness events from the poll wakeup.
+    fn poll(&mut self) -> Result<bool> {
+        self.poll.poll(&mut self.events, None)?;
+
+        for event in self.events.iter() {
+            match event.token() {
+                WAKE_TOKEN => {
+                    debug!("WAKE: wake event, will process requests");
+                }
+                token => {
+                    debug!("[{:?}]: connection ready: {:?}", token, event);
+                    let done = if let Some(connection) = self.connections.get_mut(token.0) {
+                        match connection.handle_event(Some(event), self.poll.registry()) {
+                            Ok(done) => done,
+                            Err(e) => {
+                                error!("[{:?}]: connection error: {:?}", token, e);
+                                true
+                            }
+                        }
+                    } else {
+                        debug!("[{:?}]: token not found in slab: {:?}", token, event);
+                        debug_assert!(false); // This shouldn't happen, catch it in debug mode.
+                        false
+                    };
+                    if done {
+                        debug!("[{:?}]: done, removing", token);
+                        let connection = self.connections.remove(token.0);
+                        connection.shutdown(self.poll.registry())?;
+                    }
+                }
+            }
+        }
+
+        // If the waker was signalled there may be pending requests to process.
+        while let Ok(req) = self.requests.try_recv() {
+            match req {
+                Request::AddConnection(pipe, driver, tx) => {
+                    debug!("EventLoop: handling add_connection");
+                    let r = self.add_connection(pipe, driver);
+                    tx.send(r).expect("EventLoop::add_connection");
+                }
+                Request::Shutdown => {
+                    debug!("EventLoop: handling shutdown");
+                    return Ok(false);
+                }
+                Request::WakeConnection(token) => {
+                    debug!("EventLoop: handling wake_connection [{:?}]", token);
+                    if let Some(connection) = self.connections.get_mut(token.0) {
+                        match connection.handle_event(None, self.poll.registry()) {
+                            Ok(done) => assert_eq!(done, false),
+                            Err(e) => {
+                                error!("[{:?}]: connection error: {:?}", token, e);
+                            }
+                        }
+                    } else {
+                        debug!("[{:?}]: token not found in slab: wake_connection", token);
+                        debug_assert!(false); // This shouldn't happen, catch it in debug mode.
+                    };
+                }
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+// Connection wraps an interprocess connection (Pipe) and manages
+// receiving inbound and sending outbound buffers (and associated handles, if any).
+// The associated driver is responsible for message framing and serialization.
+struct Connection {
+    io: sys::Pipe,
+    token: Token,
+    interest: Interest,
+    inbound: sys::ConnectionBuffer,
+    outbound: sys::ConnectionBuffer,
+    driver: Box<dyn Driver + Send>,
+}
+
+const IPC_CLIENT_BUFFER_SIZE: usize = 16384;
+
+impl Connection {
+    fn new(
+        mut io: sys::Pipe,
+        token: Token,
+        driver: Box<dyn Driver + Send>,
+        registry: &Registry,
+    ) -> Result<Connection> {
+        let interest = Interest::READABLE;
+        registry.register(&mut io, token, interest)?;
+        Ok(Connection {
+            io,
+            token,
+            interest,
+            inbound: sys::ConnectionBuffer::with_capacity(IPC_CLIENT_BUFFER_SIZE),
+            outbound: sys::ConnectionBuffer::with_capacity(IPC_CLIENT_BUFFER_SIZE),
+            driver,
+        })
+    }
+
+    fn shutdown(mut self, registry: &Registry) -> Result<()> {
+        registry.deregister(&mut self.io)
+    }
+
+    // Update connection registration with the current readiness event interests.
+    fn update_registration(&mut self, registry: &Registry) -> Result<()> {
+        registry.reregister(&mut self.io, self.token, self.interest)
+    }
+
+    // Handle readiness event.  Errors returned are fatal for this connection, resulting in removal from the EventLoop connection list.
+    // The EventLoop will call this for any connection that has received an event, including external wake events to clear the outbound buffer.
+    fn handle_event(&mut self, event: Option<&Event>, registry: &Registry) -> Result<bool> {
+        if let Some(event) = event {
+            assert_eq!(self.token, event.token());
+        }
+        debug!("[{:?}]: handling event {:?}", self.token, event);
+
+        // If the connection is readable, read into inbound and pass to driver for processing until all ready data
+        // has been consumed.
+        //let done = if let Some(event) = event {
+        let done = if let Some(event) = event {
+            if event.is_readable() {
+                loop {
+                    trace!("[{:?}]: pre-recv inbound: {:?}", self.token, self.inbound);
+                    let r = self.io.recv_msg(&mut self.inbound);
+                    match r {
+                        Ok(0) => {
+                            trace!("[{:?}]: recv EOF", self.token);
+                            assert!(self.inbound.is_empty()); // Ensure no unprocessed messages queued.
+                            return Ok(true);
+                        }
+                        Ok(n) => {
+                            trace!("[{:?}]: recv bytes: {}, process_inbound", self.token, n);
+                            let r = self.driver.process_inbound(&mut self.inbound);
+                            trace!("[{:?}]: process_inbound done: {:?}", self.token, r);
+                            match r {
+                                Ok(done) => {
+                                    if done {
+                                        break done;
+                                    }
+                                }
+                                Err(e) => {
+                                    error!("[{:?}]: process_inbound error: {:?}", self.token, e);
+                                    assert!(self.inbound.is_empty()); // Ensure no unprocessed messages queued.
+                                    return Err(e);
+                                }
+                            }
+                        }
+                        Err(ref e) if would_block(e) => {
+                            trace!("[{:?}]: recv would_block: {:?}", self.token, e);
+                            break false;
+                        }
+                        Err(ref e) if interrupted(e) => {
+                            trace!("[{:?}]: recv interrupted: {:?}", self.token, e);
+                            continue;
+                        }
+                        Err(e) => {
+                            error!("[{:?}]: recv error: {:?}", self.token, e);
+                            return Err(e);
+                        }
+                    }
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        // Enqueue outbound messages to the outbound buffer, then try to write out to connection.
+        // There may be outbound messages even if there was no inbound processing, so always attempt
+        // to enqueue and flush.
+        trace!("[{:?}]: flush_outbound", self.token);
+        let r = self.driver.flush_outbound(&mut self.outbound);
+        trace!("[{:?}]: flush_outbound done: {:?}", self.token, r);
+        match r {
+            Err(e) => {
+                error!("[{:?}]: flush_outbound error: {:?}", self.token, e);
+                return Err(e);
+            }
+            _ => {}
+        }
+
+        // Attempt to flush outbound buffer.  If the connection's write buffer is full, register for WRITABLE
+        // and complete flushing when associated notitication arrives later.
+        while !self.outbound.is_empty() {
+            let r = self.io.send_msg(&mut self.outbound);
+            match r {
+                Ok(0) => {
+                    trace!("[{:?}]: send EOF", self.token);
+                    return Ok(true);
+                }
+                Ok(n) => {
+                    trace!("[{:?}]: send bytes: {}", self.token, n);
+                }
+                Err(ref e) if would_block(e) => {
+                    trace!("[{:?}]: send would_block: {:?}", self.token, e);
+                    // Register for write events.
+                    if !self.interest.is_writable() {
+                        self.interest.add(Interest::WRITABLE);
+                        self.update_registration(registry)?;
+                    }
+                    break;
+                }
+                Err(ref e) if interrupted(e) => {
+                    trace!("[{:?}]: send interrupted: {:?}", self.token, e);
+                    continue;
+                }
+                Err(e) => {
+                    error!("[{:?}]: send error: {:?}", self.token, e);
+                    return Err(e);
+                }
+            }
+            trace!(
+                "[{:?}]: post-send: outbound {:?}",
+                self.token,
+                self.outbound
+            );
+        }
+
+        // If driver is done, stop reading.  We may have more outbound to flush.
+        if done {
+            trace!("[{:?}]: driver done, clearing read interest", self.token);
+            self.interest.remove(Interest::READABLE);
+            self.update_registration(registry)?;
+        }
+
+        // Outbound buffer flushed, clear registration for WRITABLE.
+        // Note that Windows NamedPipes will cause an additional WRITABLE notification after a write, even if
+        // we're no longer registered for WRITABLE.  Any user of Poll is expected to handle spurious events,
+        // so this is fine.
+        if let Some(event) = event {
+            if event.is_writable() && self.outbound.is_empty() {
+                trace!(
+                    "[{:?}]: outbound empty, clearing write interest",
+                    self.token
+                );
+                self.interest.remove(Interest::WRITABLE);
+                self.update_registration(registry)?;
+            }
+        }
+
+        debug!("[{:?}]: handling event done", self.token);
+        Ok(done && self.outbound.is_empty())
+    }
+}
+
+fn would_block(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::WouldBlock
+}
+
+fn interrupted(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::Interrupted
+}
+
+// Driver only has a single implementation, but must be hidden behind a Trait object to
+// hide the varying FramedDriver sizes (due to different `T` values).
+trait Driver {
+    // Handle inbound messages.  Returns true if Driver is done; this will trigger Connection removal and cleanup.
+    fn process_inbound(&mut self, inbound: &mut sys::ConnectionBuffer) -> Result<bool>;
+
+    // Write outbound messages to `outbound`.
+    fn flush_outbound(&mut self, outbound: &mut sys::ConnectionBuffer) -> Result<()>;
+}
+
+// Length-delimited connection framing and (de)serialization is handled by the inbound and outbound processing.
+// Handlers can then process message Requests and Responses without knowledge of serialization or
+// handle remoting.
+impl<T> Driver for FramedDriver<T>
+where
+    T: Handler,
+    T::In: DeserializeOwned + Debug + AssocRawPlatformHandle,
+    T::Out: Serialize + Debug + AssocRawPlatformHandle,
+{
+    // Caller passes `inbound` data, this function will trim any complete messages from `inbound` and pass them to the handler for processing.
+    fn process_inbound(&mut self, inbound: &mut sys::ConnectionBuffer) -> Result<bool> {
+        debug!("process_inbound: {:?}", inbound);
+
+        // Repeatedly call `decode` as long as it produces items, passing each produced item to the handler to action.
+        #[allow(unused_mut)]
+        while let Some(mut item) = self.codec.decode(&mut inbound.buf)? {
+            #[cfg(unix)]
+            {
+                let mut handle = None;
+                let b = inbound.cmsg.clone().freeze();
+                for fd in cmsg::iterator(b) {
+                    assert_eq!(fd.len(), 1);
+                    assert!(handle.is_none());
+                    handle = Some(fd[0]);
+                }
+                item.set_owned_handle(|| handle);
+            }
+            self.handler.consume(item)?;
+        }
+
+        Ok(false)
+    }
+
+    // Caller will try to write `outbound` to associated connection, queuing any data that can't be transmitted immediately.
+    fn flush_outbound(&mut self, outbound: &mut sys::ConnectionBuffer) -> Result<()> {
+        debug!("flush_outbound: {:?}", outbound.buf);
+
+        // Repeatedly grab outgoing items from the handler, passing each to `encode` for serialization into `outbound`.
+        while let Some(mut item) = self.handler.produce()? {
+            let handle = item.take_handle_for_send();
+
+            // On Windows, the handle is transferred by duplicating it into the target remote process during message send.
+            #[cfg(windows)]
+            if let Some((handle, target_pid)) = handle {
+                let remote_handle = unsafe { duplicate_platform_handle(handle, Some(target_pid))? };
+                trace!(
+                    "item handle: {:?} remote_handle: {:?}",
+                    handle,
+                    remote_handle
+                );
+                // The new handle in the remote process is indicated by updating the handle stored in the item with the expected
+                // value on the remote.
+                item.set_remote_handle_value(|| Some(remote_handle));
+            }
+            // On Unix, the handle is encoded into a cmsg buffer for out-of-band transport via sendmsg.
+            #[cfg(unix)]
+            if let Some((handle, _)) = handle {
+                item.set_remote_handle_value(|| Some(handle));
+            }
+
+            self.codec.encode(item, &mut outbound.buf)?;
+
+            #[cfg(unix)]
+            if handle.is_some() {
+                cmsg::builder(&mut outbound.cmsg).rights(&[handle.0]);
+            }
+        }
+        Ok(())
+    }
+}
+
+struct FramedDriver<T: Handler> {
+    codec: LengthDelimitedCodec<T::Out, T::In>,
+    handler: T,
+}
+
+impl<T: Handler> FramedDriver<T> {
+    fn new(handler: T) -> FramedDriver<T> {
+        FramedDriver {
+            codec: Default::default(),
+            handler,
+        }
+    }
+}
+
+// TODO: Stand-in impls, replace with rpc::Client/rpc::Server
+struct ClientTestImpl {}
+
+impl RpcClient for ClientTestImpl {
+    type Request = ServerMessage;
+    type Response = ClientMessage;
+}
+
+struct ServerTestImpl {}
+
+impl RpcServer for ServerTestImpl {
+    type Request = ServerMessage;
+    type Response = ClientMessage;
+
+    fn process(&mut self, req: Self::Request) -> Self::Response {
+        eprintln!("ServerTestImpl: got req: {:?}", req);
+        ClientMessage::StreamStarted
+    }
+}
+
+// TODO: Make test Server/Client and bounce a simple message back and forth
+pub fn test_run() -> std::result::Result<(), std::io::Error> {
+    // Setup server loop, register ServerTestImpl
+    debug!("test_run: start server loop");
+    let mut server_loop = EventLoop::new()?;
+    let server_rpc = server_loop.handle();
+    let server_thread: std::thread::JoinHandle<Result<()>> = std::thread::spawn(move || {
+        while server_loop.poll()? {
+            debug!("server poll step");
+        }
+        Ok(())
+    });
+
+    debug!("test_run: register server on server loop");
+    let client_pipe = server_rpc.new_server(ServerTestImpl {}).unwrap();
+
+    // Setup client loop, register ClientTestImpl
+    debug!("test_run: start client loop");
+    let mut client_loop = EventLoop::new()?;
+    let client_rpc = client_loop.handle();
+    let client_thread: std::thread::JoinHandle<Result<()>> = std::thread::spawn(move || {
+        while client_loop.poll()? {
+            debug!("client poll step");
+        }
+        Ok(())
+    });
+
+    let client_pipe = unsafe { sys::Pipe::from_raw_handle(client_pipe.into_raw()) };
+
+    debug!("test_run: register client on client loop");
+    let client_proxy = client_rpc
+        .new_client::<ClientTestImpl>(client_pipe)
+        .unwrap();
+
+    debug!("test_run: send StreamStart(42), wait for response");
+    let response = client_proxy
+        .call(ServerMessage::StreamStart(42))
+        .wait()
+        .unwrap();
+    debug!("test_run: got response = {:?}", response);
+
+    client_rpc.shutdown();
+    server_rpc.shutdown();
+    server_thread.join().unwrap().unwrap();
+    client_thread.join().unwrap().unwrap();
+    Ok(())
+}

--- a/audioipc/src/rpccore.rs
+++ b/audioipc/src/rpccore.rs
@@ -1,0 +1,217 @@
+// Copyright © 2021 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details
+
+use std::io::Result;
+use std::{collections::VecDeque, sync::mpsc};
+
+use mio_07::Token;
+
+use crate::ipccore::EventLoopHandle;
+
+// RPC message handler.  Implemented by ClientHandler (for RpcClient)
+// and ServerHandler (for RpcServer).
+pub trait Handler {
+    type In;
+    type Out;
+
+    // Consume a request
+    fn consume(&mut self, request: Self::In) -> Result<()>;
+
+    // Produce a response
+    fn produce(&mut self) -> Result<Option<Self::Out>>;
+}
+
+// TODO: Rename traits after tokio code removed.
+
+// Client RPC definition.  This supplies the expected message
+// request and response types.
+pub trait RpcClient {
+    type Request;
+    type Response;
+}
+
+// Server RPC definition.  This supplies the expected message
+// request and response types.  `process` is passed inbound RPC
+// requests by the ServerHandler to be responded to by the server.
+pub trait RpcServer {
+    type Request;
+    type Response;
+
+    fn process(&mut self, req: Self::Request) -> Self::Response;
+}
+
+// RPC Client Proxy implementation
+type ProxyRequest<R, Q> = (R, mpsc::Sender<Q>);
+type ProxyReceiver<R, Q> = mpsc::Receiver<ProxyRequest<R, Q>>;
+
+// Each RPC Proxy `call` returns a blocking waitable ProxyResponse.
+// `wait` produces the response received over RPC from the associated
+// Proxy `call`.
+pub struct ProxyResponse<Q> {
+    inner: mpsc::Receiver<Q>,
+}
+
+impl<Q> ProxyResponse<Q> {
+    pub fn wait(&self) -> Result<Q> {
+        match self.inner.recv() {
+            Ok(resp) => Ok(resp),
+            Err(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "proxy recv error",
+            )),
+        }
+    }
+}
+
+// RPC Proxy that may be `clone`d for use by multiple owners/threads.
+// A Proxy `call` arranges for the supplied request to be transmitted
+// to the associated Server via RPC.  The response can be retrieved by
+// `wait`ing on the returned ProxyResponse.
+pub struct Proxy<R, Q> {
+    handle: Option<(EventLoopHandle, Token)>,
+    tx: mpsc::Sender<ProxyRequest<R, Q>>,
+}
+
+impl<R, Q> Proxy<R, Q> {
+    pub fn call(&self, request: R) -> ProxyResponse<Q> {
+        let (tx, rx) = mpsc::channel();
+        self.tx.send((request, tx)).expect("proxy send error");
+        let (handle, token) = self
+            .handle
+            .as_ref()
+            .expect("proxy not connected to event loop");
+        handle.wake_connection(*token);
+        ProxyResponse { inner: rx }
+    }
+
+    pub(crate) fn connect_event_loop(&mut self, handle: EventLoopHandle, token: Token) {
+        self.handle = Some((handle, token));
+    }
+}
+
+impl<R, Q> Clone for Proxy<R, Q> {
+    fn clone(&self) -> Self {
+        Proxy {
+            handle: self.handle.clone(),
+            tx: self.tx.clone(),
+        }
+    }
+}
+
+fn make_proxy<R, Q>() -> (Proxy<R, Q>, ProxyReceiver<R, Q>) {
+    let (tx, rx) = mpsc::channel();
+    let proxy = Proxy { handle: None, tx };
+    (proxy, rx)
+}
+
+// Client-specific Handler implementation.
+// The IPC Core `Driver` calls this to execute client-specific
+// RPC handling.  Serialized messages sent via a Proxy are queued
+// for transmission when `produce` is called.
+// Deserialized messages are passed via `consume` to
+// trigger response completion by sending the response via a channel
+// connected to a ProxyResponse.
+pub struct ClientHandler<C: RpcClient> {
+    requests: ProxyReceiver<C::Request, C::Response>,
+    in_flight: VecDeque<mpsc::Sender<C::Response>>,
+}
+
+impl<C: RpcClient> Handler for ClientHandler<C> {
+    type In = C::Response;
+    type Out = C::Request;
+
+    fn consume(&mut self, response: Self::In) -> Result<()> {
+        trace!("ClientHandler::consume");
+        if let Some(complete) = self.in_flight.pop_front() {
+            drop(complete.send(response));
+        } else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "request/response mismatch",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn produce(&mut self) -> Result<Option<Self::Out>> {
+        trace!("ClientHandler::produce");
+
+        // Try to get a new request
+        match self.requests.try_recv() {
+            Ok((request, complete)) => {
+                trace!("  --> received request");
+                self.in_flight.push_back(complete);
+                Ok(Some(request))
+            }
+            Err(mpsc::TryRecvError::Empty) => {
+                trace!("  --> no request");
+                Ok(None)
+            }
+            Err(mpsc::TryRecvError::Disconnected) => {
+                trace!("  --> client disconnected");
+                Ok(None) // TODO: Report useful error?
+            }
+        }
+    }
+}
+
+pub fn make_client<C: RpcClient>() -> (ClientHandler<C>, Proxy<C::Request, C::Response>) {
+    let (tx, rx) = make_proxy();
+
+    let handler = ClientHandler::<C> {
+        requests: rx,
+        in_flight: VecDeque::with_capacity(32),
+    };
+
+    (handler, tx)
+}
+
+// Server-specific Handler implementation.
+// The IPC Core `Driver` calls this to execute server-specific
+// RPC handling.  Deserialized messages are passed via `consume` to the
+// associated `server` for processing.  Server responses are then queued
+// for RPC to the associated client when `produce` is called.
+pub struct ServerHandler<S: RpcServer> {
+    server: S,
+    in_flight: VecDeque<S::Response>,
+}
+
+impl<S: RpcServer> Handler for ServerHandler<S> {
+    type In = S::Request;
+    type Out = S::Response;
+
+    fn consume(&mut self, request: Self::In) -> Result<()> {
+        trace!("ServerHandler::consume");
+        let response = self.server.process(request);
+        self.in_flight.push_back(response);
+        Ok(())
+    }
+
+    fn produce(&mut self) -> Result<Option<Self::Out>> {
+        trace!("ServerHandler::produce");
+
+        // Return the ready response
+        match self.in_flight.pop_front() {
+            Some(res) => {
+                trace!("  --> received response");
+                Ok(Some(res))
+            }
+            None => {
+                trace!("  --> no response ready");
+                Ok(None)
+            }
+        }
+    }
+}
+
+pub fn make_server<S: RpcServer>(server: S) -> ServerHandler<S> {
+    let handler = ServerHandler::<S> {
+        server,
+        in_flight: VecDeque::with_capacity(32),
+    };
+
+    handler
+}

--- a/audioipc/src/sys/mod.rs
+++ b/audioipc/src/sys/mod.rs
@@ -1,0 +1,44 @@
+// Copyright © 2021 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details
+
+use std::io::Result;
+
+use mio_07::{event::Source, Interest, Registry, Token};
+
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use self::unix::*;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub use self::windows::*;
+
+impl Source for Pipe {
+    fn register(&mut self, registry: &Registry, token: Token, interests: Interest) -> Result<()> {
+        self.0.register(registry, token, interests)
+    }
+
+    fn reregister(&mut self, registry: &Registry, token: Token, interests: Interest) -> Result<()> {
+        self.0.reregister(registry, token, interests)
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> Result<()> {
+        self.0.deregister(registry)
+    }
+}
+
+pub trait RecvMsg {
+    // Receive data from the associated connection.  `recv_msg` expects the capacity of
+    // the `ConnectionBuffer` members has been adjusted appropriate by the caller.
+    fn recv_msg(&mut self, buf: &mut ConnectionBuffer) -> Result<usize>;
+}
+
+pub trait SendMsg {
+    // Send data on the associated connection.  `send_msg` adjusts the length of the
+    // `ConnectionBuffer` members based on the size of the successful send operation.
+    fn send_msg(&mut self, buf: &mut ConnectionBuffer) -> Result<usize>;
+}

--- a/audioipc/src/sys/unix/mod.rs
+++ b/audioipc/src/sys/unix/mod.rs
@@ -1,0 +1,125 @@
+// Copyright © 2021 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details
+
+use std::io::Result;
+use std::os::unix::prelude::{AsRawFd, RawFd};
+
+use bytes::{Buf, BufMut, BytesMut, IntoBuf};
+use iovec::IoVec;
+use mio_07::net::UnixStream;
+
+use crate::{close_platform_handle, cmsg, msg, PlatformHandle};
+
+use super::{RecvMsg, SendMsg};
+
+pub struct Pipe(pub UnixStream);
+
+// Create a connected "pipe" pair.  The `Pipe` is the server end,
+// the `PlatformHandle` is the client end to be remoted.
+pub fn make_pipe_pair() -> Result<(Pipe, PlatformHandle), std::io::Error> {
+    let (server, client) = UnixStream::pair()?;
+    Ok((Pipe(server), PlatformHandle::from(client)))
+}
+
+impl Pipe {
+    pub unsafe fn from_raw_handle(raw: crate::PlatformHandleType) -> Pipe {
+        Pipe(UnixStream::from_raw_fd(raw))
+    }
+}
+
+impl RecvMsg for Pipe {
+    // Receive data (and fds) from the associated connection.  `recv_msg` expects the capacity of
+    // the `ConnectionBuffer` members has been adjusted appropriate by the caller.
+    fn recv_msg(&mut self, buf: &mut ConnectionBuffer) -> Result<usize> {
+        assert!(buf.buf.remaining_mut() > 0);
+        assert!(buf.cmsg.remaining_mut() > 0);
+        let r = unsafe {
+            let mut iovec = [<&mut IoVec>::from(buf.buf.bytes_mut())];
+            #[cfg(target_os = "linux")]
+            let flags = libc::MSG_CMSG_CLOEXEC;
+            #[cfg(not(target_os = "linux"))]
+            let flags = 0;
+            msg::recv_msg_with_flags(self.0.as_raw_fd(), &mut iovec, buf.cmsg.bytes_mut(), flags)
+        };
+        match r {
+            Ok((n, cmsg_n, flags)) => unsafe {
+                assert_eq!(flags, 0);
+                buf.buf.advance_mut(n);
+                buf.cmsg.advance_mut(cmsg_n);
+                Ok(n)
+            },
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl SendMsg for Pipe {
+    // Send data (and fds) on the associated connection.  `send_msg` adjusts the length of the
+    // `ConnectionBuffer` members based on the size of the successful send operation.
+    fn send_msg(&mut self, buf: &mut ConnectionBuffer) -> Result<usize> {
+        assert!(buf.buf.len() > 0);
+        let r = {
+            let iovec = [<&IoVec>::from(&buf.buf[..buf.buf.len()])];
+            msg::send_msg_with_flags(self.0.as_raw_fd(), &iovec, &buf.cmsg[..buf.cmsg.len()], 0)
+        };
+        match r {
+            Ok(n) => {
+                buf.buf.advance(n);
+                // Close sent fds.
+                let b = buf.cmsg.clone().freeze();
+                for fd in cmsg::iterator(b) {
+                    assert_eq!(fd.len(), 1);
+                    unsafe {
+                        close_platform_handle(fd[0]);
+                    }
+                }
+                buf.cmsg.clear();
+                Ok(n)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+// Platform-specific wrapper around `BytesMut`.
+// `cmsg` is a secondary buffer used for sending/receiving
+// fds via `sendmsg`/`recvmsg` on a Unix Domain Socket.
+#[derive(Debug)]
+pub struct ConnectionBuffer {
+    pub buf: BytesMut,
+    pub cmsg: BytesMut,
+}
+
+impl ConnectionBuffer {
+    pub fn with_capacity(cap: usize) -> Self {
+        ConnectionBuffer {
+            buf: BytesMut::with_capacity(cap),
+            cmsg: BytesMut::with_capacity(cmsg::space(std::mem::size_of::<RawFd>())),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buf.is_empty() && self.cmsg.is_empty()
+    }
+}
+
+// Close any unprocessed fds in cmsg buffer.
+impl Drop for ConnectionBuffer {
+    fn drop(&mut self) {
+        if !self.cmsg.is_empty() {
+            debug!(
+                "ConnectionBuffer dropped with {} bytes in cmsg",
+                self.cmsg.len()
+            );
+            let b = self.cmsg.clone().freeze();
+            for fd in cmsg::iterator(b) {
+                assert_eq!(fd.len(), 1);
+                unsafe {
+                    close_platform_handle(fd[0]);
+                }
+            }
+        }
+    }
+}

--- a/audioipc/src/sys/windows/mod.rs
+++ b/audioipc/src/sys/windows/mod.rs
@@ -1,0 +1,102 @@
+// Copyright © 2021 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details
+
+use std::{
+    fs::OpenOptions,
+    io::{Read, Write},
+    os::windows::prelude::{FromRawHandle, OpenOptionsExt},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use std::io::Result;
+
+use bytes::{BufMut, BytesMut};
+use mio_07::windows::NamedPipe;
+use winapi::um::winbase::FILE_FLAG_OVERLAPPED;
+
+use crate::PlatformHandle;
+
+use super::{RecvMsg, SendMsg};
+
+pub struct Pipe(pub NamedPipe);
+
+// Create a connected "pipe" pair.  The `Pipe` is the server end,
+// the `PlatformHandle` is the client end to be remoted.
+pub fn make_pipe_pair() -> Result<(Pipe, PlatformHandle)> {
+    let pipe_name = get_pipe_name();
+    let server = NamedPipe::new(&pipe_name)?;
+
+    let client = {
+        let mut opts = OpenOptions::new();
+        opts.read(true)
+            .write(true)
+            .custom_flags(FILE_FLAG_OVERLAPPED);
+        let file = opts.open(&pipe_name)?;
+        PlatformHandle::from(file)
+    };
+
+    Ok((Pipe(server), client))
+}
+
+static PIPE_ID: AtomicUsize = AtomicUsize::new(0);
+
+fn get_pipe_name() -> String {
+    let pid = std::process::id();
+    let pipe_id = PIPE_ID.fetch_add(1, Ordering::Relaxed);
+    format!("\\\\.\\pipe\\LOCAL\\cubeb-pipe-{}-{}", pid, pipe_id)
+}
+
+impl Pipe {
+    pub unsafe fn from_raw_handle(raw: crate::PlatformHandleType) -> Pipe {
+        Pipe(NamedPipe::from_raw_handle(raw))
+    }
+}
+
+impl RecvMsg for Pipe {
+    // Receive data from the associated connection.  `recv_msg` expects the capacity of
+    // the `ConnectionBuffer` members has been adjusted appropriate by the caller.
+    fn recv_msg(&mut self, buf: &mut ConnectionBuffer) -> Result<usize> {
+        assert!(buf.buf.remaining_mut() > 0);
+        let r = unsafe { self.0.read(buf.buf.bytes_mut()) };
+        match r {
+            Ok(n) => unsafe {
+                buf.buf.advance_mut(n);
+                Ok(n)
+            },
+            e => e,
+        }
+    }
+}
+
+impl SendMsg for Pipe {
+    // Send data on the associated connection.  `send_msg` adjusts the length of the
+    // `ConnectionBuffer` members based on the size of the successful send operation.
+    fn send_msg(&mut self, buf: &mut ConnectionBuffer) -> Result<usize> {
+        assert!(buf.buf.len() > 0);
+        let r = self.0.write(&buf.buf[..buf.buf.len()]);
+        if let Ok(n) = r {
+            buf.buf.advance(n);
+        }
+        r
+    }
+}
+
+// Platform-specific wrapper around `BytesMut`.
+#[derive(Debug)]
+pub struct ConnectionBuffer {
+    pub buf: BytesMut,
+}
+
+impl ConnectionBuffer {
+    pub fn with_capacity(cap: usize) -> Self {
+        ConnectionBuffer {
+            buf: BytesMut::with_capacity(cap),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buf.is_empty()
+    }
+}


### PR DESCRIPTION
This replaces the existing IPC messaging core built around tokio 0.1 with a new one built around mio 0.7.

The intention of this change is to reduce external dependencies and tighten control over the architecture so that it can be customized for better soft-RT performance for our audio uses.  Replacing the old 0.1 IPC core also addresses the various issues that were blocking AudioIPC for macOS in Gecko.  These changes will also make it easier to introduce profiler markers in the IPC code to improve field debugability.

In the short term, this rework will exist on a branch to allow shipping Gecko's macOS build with the rework.  Once the code has been tested and stabilized on macOS, the branch will be merged with the existing code (completing the removal of any tokio 0.1 references) to become the default for all platforms.

The initial version retains a similar general architecture to the existing IPC code in terms of threading and relationships between server, client, cubeb context and cubeb stream.  With the initial rework is in place and shipping on all platforms, the intention is to then take advantage of the new architecture to enable functionality that wasn't easy to provide within the restrictions of the old architecture, including:
    - per-stream callback remoting for high priority/low latency streams
        where each stream may be serviced by it's own thread/EventLoop on the client side
    - more efficient use of shared memory segments, including using shmem for message passing
    - client-side stream multiplexing for low priority/high latency streams
        trading off latency for reduced IPC overhead
    - providing a new API for cubeb stream consumers allowing them to provide their own thread for callback processing,
      with new methods to wait for free buffer space and provide refilled buffers for capture/playback

General architecture:
- Server side:
    - Main "server" thread executing EventLoop, with one connection per client
        - Connections are Unix Domain Sockets on Unix, and Named Pipes on Windows
        - Each connection services one or more remote cubeb streams for the client
    - RPC Proxy, allowing thread-safe message send/receive, used within
        cubeb callbacks to communicate with client-side cubeb streams via EventLoop
- Client side:
    - EventLoop thread with a single connection, communicating with server
    - RPC Proxy per cubeb stream, remoting cubeb API calls to the server (via EventLoop)

TODO:
- Remove existing tokio 0.1 code and deps (once all platforms switched over)
- Delete tokio_named_pipes, tokio_uds_stream
- Delete AsyncSendMsg/AsyncRecvMsg traits/impls
