### PR TITLE
server: Handle client error during stream_init shmem setup.

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -759,7 +759,14 @@ impl CubebServer {
         let user_ptr = server_stream.cbs.as_ref() as *const ServerStreamCallbacks as *mut c_void;
 
         // SharedMem setup message should've been processed by client by now.
-        server_stream.shm_setup.take().wait().unwrap();
+        if let Err(e) = server_stream.shm_setup.take().wait() {
+            // If the client errored before responding, log error and fail stream init.
+            debug!(
+                "Shmem setup for stream {:?} failed (error {:?})",
+                stm_tok, e
+            );
+            return Err(e.into());
+        }
 
         let stream = unsafe {
             let stream = context.stream_init(


### PR DESCRIPTION
If the client abruptly disconnects (e.g. crashed) between the first and second phase of stream init, waiting for the `shm_setup` response on the server can result in an error.  Handle this gracefully rather than unwrapping the response.

Addresses [BMO #1725749](https://bugzilla.mozilla.org/show_bug.cgi?id=1725749).