### PR TITLE
client: Make shmem and input copy allocations fallible, signal error to server on failure

### DIFF
--- a/audioipc/src/messages.rs
+++ b/audioipc/src/messages.rs
@@ -273,6 +273,7 @@ pub enum CallbackResp {
     State,
     DeviceChange,
     SharedMem,
+    Error(c_int),
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,3 +17,4 @@ futures = { version="0.1.18", default-features=false, features=["use_std"] }
 futures-cpupool = { version="0.1.8", default-features=false }
 log = "0.4"
 tokio = "0.1"
+fallible_collections = "0.4"


### PR DESCRIPTION
Add error message to CallbackReq for signalling client-side callback errors.  Handle this on the server side when waiting for shmem setup to complete.

This addresses the OOM-related crashed for 32-bit Windows in [BMO 1730518](https://bugzilla.mozilla.org/show_bug.cgi?id=1730518).  This should be simple/safe enough to uplift to beta 94.

I'm testing a follow-up fix/improvement that sizes the shmem appropriately for each stream - I'll post the PR soon.  That's more experimental, so I intend to land that only in nightly.