### PR TITLE
server: Estimate shm_area_size based on stream config.

### DIFF
--- a/ipctest/src/main.rs
+++ b/ipctest/src/main.rs
@@ -25,9 +25,6 @@ mod errors {
 
 use crate::errors::*;
 
-// TODO: Remove hardcoded size and allow allocation based on cubeb backend requirements.
-pub const SHM_AREA_SIZE: usize = 2 * 1024 * 1024;
-
 // Run with 'RUST_LOG=run,audioipc cargo run -p ipctest'
 #[cfg(unix)]
 fn run() -> Result<()> {
@@ -35,7 +32,7 @@ fn run() -> Result<()> {
 
     let handle =
         unsafe { audioipc_server::audioipc_server_start(std::ptr::null(), std::ptr::null()) };
-    let fd = audioipc_server::audioipc_server_new_client(handle, SHM_AREA_SIZE);
+    let fd = audioipc_server::audioipc_server_new_client(handle, 0);
     let fd = unsafe {
         let new_fd = libc::dup(fd);
         libc::close(fd);
@@ -98,7 +95,7 @@ fn run_client() -> Result<()> {
 fn run() -> Result<()> {
     let handle =
         unsafe { audioipc_server::audioipc_server_start(std::ptr::null(), std::ptr::null()) };
-    let fd = audioipc_server::audioipc_server_new_client(handle, SHM_AREA_SIZE);
+    let fd = audioipc_server::audioipc_server_new_client(handle, 0);
 
     let args: Vec<String> = std::env::args().collect();
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -123,6 +123,8 @@ pub unsafe extern "C" fn audioipc_server_start(
     }
 }
 
+// A `shm_area_size` of 0 allows the server to calculate an appropriate shm size for each stream.
+// A non-zero `shm_area_size` forces all allocations to the specified size.
 #[no_mangle]
 pub extern "C" fn audioipc_server_new_client(
     p: *mut c_void,


### PR DESCRIPTION
The shm_area_size parameter to audioipc_server_new_client now serves as a hard override to force a specific shm area size.  The default value of 0 allows the server to estimate an appropriate size for each stream.  For common streams, this reduces the shm overhead from ~2MB to ~192kB.

This is a short term improvement until issue 124 is addressed.  With issue 124 addressed, it should be possible to reduce shm overhead to ~20-64kB.