### PR TITLE
server: Register server threads via supplied callback.

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -23,8 +23,6 @@ use std::os::raw::{c_char, c_int};
 thread_local!(static IN_CALLBACK: std::cell::RefCell<bool> = std::cell::RefCell::new(false));
 thread_local!(static AUDIOIPC_INIT_PARAMS: std::cell::RefCell<Option<AudioIpcInitParams>> = std::cell::RefCell::new(None));
 
-// This must match the definition of AudioIpcInitParams in
-// dom/media/CubebUtils.cpp in Gecko.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct AudioIpcInitParams {

--- a/ipctest/src/main.rs
+++ b/ipctest/src/main.rs
@@ -29,9 +29,13 @@ use crate::errors::*;
 #[cfg(unix)]
 fn run() -> Result<()> {
     use std::ffi::CString;
-
-    let handle =
-        unsafe { audioipc_server::audioipc_server_start(std::ptr::null(), std::ptr::null()) };
+    let init_params = audioipc_server::AudioIpcServerInitParams {
+        thread_create_callback: None,
+        thread_destroy_callback: None,
+    };
+    let handle = unsafe {
+        audioipc_server::audioipc_server_start(std::ptr::null(), std::ptr::null(), &init_params)
+    };
     let fd = audioipc_server::audioipc_server_new_client(handle, 0);
     let fd = unsafe {
         let new_fd = libc::dup(fd);
@@ -93,8 +97,13 @@ fn run_client() -> Result<()> {
 #[allow(clippy::unnecessary_wraps)]
 #[cfg(windows)]
 fn run() -> Result<()> {
-    let handle =
-        unsafe { audioipc_server::audioipc_server_start(std::ptr::null(), std::ptr::null()) };
+    let init_params = audioipc_server::AudioIpcServerInitParams {
+        thread_create_callback: None,
+        thread_destroy_callback: None,
+    };
+    let handle = unsafe {
+        audioipc_server::audioipc_server_start(std::ptr::null(), std::ptr::null(), &init_params)
+    };
     let fd = audioipc_server::audioipc_server_new_client(handle, 0);
 
     let args: Vec<String> = std::env::args().collect();


### PR DESCRIPTION
This will be used by Gecko to link AudioIPC server threads to the Firefox Profiler as discussed in [BMO 1728023](https://bugzilla.mozilla.org/show_bug.cgi?id=1728023).