### PR TITLE
Use ashmem crate from crates.io

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -36,7 +36,7 @@ mio-named-pipes = { git = "https://github.com/kinetiknz/mio-named-pipes", rev = 
 winapi = { version = "0.3.6", features = ["combaseapi", "memoryapi", "objbase"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-ashmem = { git = "https://github.com/kinetiknz/ashmem-rs", rev = "e47f470a54193532d60057ec54f864e06aeaff36" }
+ashmem = "0.1"
 
 [dependencies.error-chain]
 version = "0.11.0"


### PR DESCRIPTION
ashmem 0.1 is yanked on crates.io making `cargo audit` warn against it.

It doesn't seem there is much difference between the pinned git version here and the latest version on the crates.io: https://github.com/kinetiknz/ashmem-rs/commits/master and I believe it's normally preferable if we can use the crate from crates.io rather than pin a git revision.