### PR TITLE
Drop `fallible_collections` and switch to Rust 1.57 fallible allocations.

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,4 +17,3 @@ futures = { version="0.1.18", default-features=false, features=["use_std"] }
 futures-cpupool = { version="0.1.8", default-features=false }
 log = "0.4"
 tokio = "0.1"
-fallible_collections = "0.4"

--- a/client/src/stream.rs
+++ b/client/src/stream.rs
@@ -13,7 +13,6 @@ use audioipc::{
     messages::{self, CallbackReq, CallbackResp, ClientMessage, ServerMessage},
 };
 use cubeb_backend::{ffi, DeviceRef, Error, Result, Stream, StreamOps};
-use fallible_collections::FallibleVec;
 use futures::Future;
 use futures_cpupool::{CpuFuture, CpuPool};
 use std::ffi::{CStr, CString};
@@ -212,8 +211,9 @@ impl rpc::Server for CallbackServer {
                 };
 
                 self.duplex_input = if let StreamDirection::Duplex = self.dir {
-                    match Vec::try_with_capacity(shm_area_size) {
-                        Ok(duplex_input) => Some(duplex_input),
+                    let mut duplex_input = Vec::new();
+                    match duplex_input.try_reserve_exact(shm_area_size) {
+                        Ok(()) => Some(duplex_input),
                         Err(e) => {
                             warn!(
                                 "duplex_input allocation failed (size={}, err={:?})",


### PR DESCRIPTION
Per [BMO 1744102](https://bugzilla.mozilla.org/show_bug.cgi?id=1744102), there's a desire to switch to Rust's built-in fallible allocations now that they're stable in 1.57.