### PR TITLE
Various fixes for "Core IPC messaging rewrite" (PR #130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ process is done externally, in Gecko code.
   EventLoopThread per ClientStream.
 - The server side remoting layer (located in the `server` crate) contains
   CubebServer, which adapts both context and stream RPCs to native cubeb API
-  calls.  This is driven by a single pair of "Server RPC" and "Server
-  Callback" EventLoopThreads servicing all CubebServer instances.
+  calls.  This is driven by a single trio of "Server RPC", "Server
+  Callback", and "Server DeviceCollection RPC) EventLoopThreads servicing all
+  CubebServer instances.
 - Core RPC and IPC functionality and support code is located in the `audioipc` crate.
   - The RPC interface provides a Client trait specifying message types the
     client implementation will use, and a Server trait specifying message

--- a/audioipc/src/codec.rs
+++ b/audioipc/src/codec.rs
@@ -175,7 +175,9 @@ where
             }
         }
 
-        buf.put_u32_le(self.encode_buf.len().try_into().unwrap());
+        let encoded_len = self.encode_buf.len();
+        buf.reserve(encoded_len + size_of::<u32>());
+        buf.put_u32_le(encoded_len.try_into().unwrap());
         buf.extend_from_slice(&self.encode_buf);
 
         Ok(())

--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -549,7 +549,7 @@ where
             {
                 // TODO: Clean this up to only expect a single fd per message.
                 let mut handle = None;
-                let b = inbound.cmsg.clone().freeze();
+                let b = inbound.cmsg.take().freeze();
                 for fd in cmsg::iterator(b) {
                     assert_eq!(fd.len(), 1);
                     assert!(handle.is_none());

--- a/audioipc/src/messages.rs
+++ b/audioipc/src/messages.rs
@@ -468,7 +468,7 @@ impl AssocRawPlatformHandle for ClientMessage {
                 let handle = f().expect("platform_handle must be available when processing ContextSetupDeviceCollectionCallback");
                 data.platform_handle = SerializableHandle::new_serializable_value(handle);
             }
-            _ => {}
+            _ => assert!(f().is_none()),
         }
     }
 
@@ -487,7 +487,7 @@ impl AssocRawPlatformHandle for ClientMessage {
                 let handle = f().expect("platform_handle must be available when processing ContextSetupDeviceCollectionCallback");
                 data.platform_handle = SerializableHandle::new_owned(handle);
             }
-            _ => {}
+            _ => assert!(f().is_none()),
         }
     }
 }
@@ -513,6 +513,8 @@ impl AssocRawPlatformHandle for CallbackReq {
         if let CallbackReq::SharedMem(ref mut data, _) = *self {
             let handle = f().expect("platform_handle must be available when processing SharedMem");
             *data = SerializableHandle::new_serializable_value(handle);
+        } else {
+            assert!(f().is_none());
         }
     }
 
@@ -524,6 +526,8 @@ impl AssocRawPlatformHandle for CallbackReq {
         if let CallbackReq::SharedMem(ref mut data, _) = *self {
             let handle = f().expect("platform_handle must be available when processing SharedMem");
             *data = SerializableHandle::new_owned(handle);
+        } else {
+            assert!(f().is_none());
         }
     }
 }

--- a/audioipc/src/rpccore.rs
+++ b/audioipc/src/rpccore.rs
@@ -174,6 +174,12 @@ pub(crate) fn make_client<C: Client>(
         in_flight: VecDeque::with_capacity(32),
     };
 
+    // Sender is Send, but !Sync, so it's not safe to move between threads
+    // without cloning it first.  Force a clone here, since we use Proxy in
+    // native code and it's possible to move it between threads without Rust's
+    // type system noticing.
+    #[allow(clippy::redundant_clone)]
+    let tx = tx.clone();
     let proxy = Proxy { handle: None, tx };
 
     (handler, proxy)

--- a/ipctest/src/client.rs
+++ b/ipctest/src/client.rs
@@ -156,7 +156,7 @@ pub fn client_test(handle: audioipc::PlatformHandleType) -> Result<()> {
     let init_params = audioipc_client::AudioIpcInitParams {
         server_connection: handle,
         pool_size: 1,
-        stack_size: 64 * 1024,
+        stack_size: 64 * 4096,
         thread_create_callback: None,
         thread_destroy_callback: None,
     };


### PR DESCRIPTION
Various fixes found while stress testing PR #130 integrated with Gecko on various platforms.

- 25ba70ed054c30dc3e83c98614ebba316ef491ad: Consume incoming cmsg buffer correctly.
  - `clone` was causing processed handles to be left in the cmsg buffer, which were then ignored when trying to associate them with the incoming message in `set_owned_handle`.
- cc170ab91be6659ae8e1715185f327db01fedcfd: Notify EventLoop when proxy dropped, and clean up broken connections when handling wakes.
  - Resulted in a shutdown hang in the AudioIPC client while waiting for the server's CallbackClient to be removed.
- 06b8727b8e771cdeba49934066a12481773ddcf2: ipctest: 64kB stack is too small for Client Callback thread on Windows.
  - ipctest was using an unusually small stack size, resulting in an intermittent crash if the Client Callback thread stack was exhausted.  This didn't show up in the old code because we bounced callback processing to the thread pool.
- 74b5f83967734ba2547da04ace9783e8b1f8f78c: Reserve appropriate buffer size in encode.
  - Bug introduced when backporting the codec.rs speed ups from my development branch (using bytes 1.1.0).
- 50ae2a6e4e2558d6dc9261ab84a78d9aff3ad1d7: Force Proxy's Sender to upgrade when created.
  - Fixes an intermittent crash in `Proxy::call` if the `Sender` happened to still be in `Oneshot` state.
- 1d255f7c7cc5a6f4350cd72e6e533e744549abbb: Use a separate EventLoopThread for device_collection_change callbacks.
  - Fixes a hang in the server when setting up `DeviceCollectionClient` in the server while processing a cubeb_register_device_collection_changed request.

This PR will be merged into the [macos branch](https://github.com/mozilla/audioipc-2/tree/macos).