### PR TITLE
Fix potential "lost" wake when dropping Proxy

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -121,16 +121,16 @@ fn init_threads(
         device_collection_name.to_string(),
         None,
         move || {
-            trace!("Starting {} thread", rpc_name);
+            trace!("Starting {} thread", device_collection_name);
             register_thread(thread_create_callback);
         },
         move || {
             unregister_thread(thread_destroy_callback);
-            trace!("Stopping {} thread", rpc_name);
+            trace!("Stopping {} thread", device_collection_name);
         },
     )
     .map_err(|e| {
-        debug!("Failed to start {} thread: {:?}", rpc_name, e);
+        debug!("Failed to start {} thread: {:?}", device_collection_name, e);
         e
     })?;
 


### PR DESCRIPTION
The fix in 50ae2a6 was incomplete, it left a potential race where the EventLoopThread associated with the Proxy would handle the wake before the Sender was dropped.  This resulted in the EventLoopThread failing to clean up a disconnected Proxy, since the last attempt to read from the Receiver the Proxy is attached to would succeed rather than fail as expected.

Follow up to https://github.com/mozilla/audioipc-2/pull/134.