### PR TITLE
Improve handle {de,}serialization logic.

### DIFF
--- a/audioipc/src/sys/unix/cmsg.rs
+++ b/audioipc/src/sys/unix/cmsg.rs
@@ -6,11 +6,12 @@
 use bytes::{BufMut, Bytes, BytesMut};
 use libc::{self, cmsghdr};
 use std::convert::TryInto;
+use std::mem::size_of;
 use std::os::unix::io::RawFd;
 use std::{convert, mem, ops, slice};
 
 #[derive(Clone, Debug)]
-pub struct Fds {
+struct Fds {
     fds: Bytes,
 }
 
@@ -30,11 +31,29 @@ impl ops::Deref for Fds {
     }
 }
 
-pub struct ControlMsgIter {
+struct ControlMsgIter {
     control: Bytes,
 }
 
-pub fn iterator(c: Bytes) -> ControlMsgIter {
+pub fn encode_handle(cmsg: &mut BytesMut, handle: RawFd) {
+    // TODO: Rework builder to commit directly to outbound buffer.
+    match builder(cmsg).rights(&[handle]).finish() {
+        Ok(handle_bytes) => cmsg.extend_from_slice(&handle_bytes),
+        Err(e) => debug!("cmsg::builder failed: {:?}", e),
+    }
+}
+
+// Decode one cmsghdr containing a handle, and adjust the `cmsg` buffer cursor past
+// the decoded handle.
+pub fn decode_handle(cmsg: &mut BytesMut) -> RawFd {
+    let b = cmsg.split_to(space(size_of::<i32>())).freeze();
+    // TODO: Clean this up to only expect a single fd per message.
+    let fd = iterator(b).next().unwrap();
+    assert_eq!(fd.len(), 1);
+    fd[0]
+}
+
+fn iterator(c: Bytes) -> ControlMsgIter {
     ControlMsgIter { control: c }
 }
 
@@ -82,17 +101,17 @@ impl Iterator for ControlMsgIter {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum Error {
+enum Error {
     /// Not enough space in storage to insert control mesage.
     NoSpace,
 }
 
 #[must_use]
-pub struct ControlMsgBuilder {
+struct ControlMsgBuilder {
     result: Result<BytesMut, Error>,
 }
 
-pub fn builder(buf: &mut BytesMut) -> ControlMsgBuilder {
+fn builder(buf: &mut BytesMut) -> ControlMsgBuilder {
     let buf = aligned(buf);
     ControlMsgBuilder { result: Ok(buf) }
 }

--- a/audioipc/src/sys/unix/mod.rs
+++ b/audioipc/src/sys/unix/mod.rs
@@ -88,15 +88,13 @@ impl SendMsg for Pipe {
             Ok(n) => {
                 buf.buf.advance(n);
                 // Close sent fds.
-                // TODO: Clean this up to only expect a single fd per message.
-                let b = buf.cmsg.clone().freeze();
-                for fd in cmsg::iterator(b) {
-                    assert_eq!(fd.len(), 1);
+                while !buf.cmsg.is_empty() {
+                    let fd = cmsg::decode_handle(&mut buf.cmsg);
                     unsafe {
-                        close_platform_handle(fd[0]);
+                        close_platform_handle(fd);
                     }
                 }
-                buf.cmsg.clear();
+                assert!(buf.cmsg.is_empty());
                 Ok(n)
             }
             Err(e) => Err(e),
@@ -134,13 +132,13 @@ impl Drop for ConnectionBuffer {
                 "ConnectionBuffer dropped with {} bytes in cmsg",
                 self.cmsg.len()
             );
-            let b = self.cmsg.clone().freeze();
-            for fd in cmsg::iterator(b) {
-                assert_eq!(fd.len(), 1);
+            while !self.cmsg.is_empty() {
+                let fd = cmsg::decode_handle(&mut self.cmsg);
                 unsafe {
-                    close_platform_handle(fd[0]);
+                    close_platform_handle(fd);
                 }
             }
+            assert!(self.cmsg.is_empty());
         }
     }
 }


### PR DESCRIPTION
This fixes an issue where the Driver would attempt to decode and associate a handle to a message that didn't expect a handle when multiple messages were present in the inbound decode buffer, triggering the assert added in https://github.com/mozilla/audioipc-2/commit/25ba70ed054c30dc3e83c98614ebba316ef491ad via PR #134.  The tests I'm adding in issue #135 will cover this case as part of the tests for the original https://github.com/mozilla/audioipc-2/commit/25ba70ed054c30dc3e83c98614ebba316ef491ad fix.

- Move cmsg handling into standalone {encode,decode}_handle functions.
- Rename AssocRawPlatformHandle to AssociateHandleForMessage
- Roll take_handle_for_send and set_remote_handle_value into
  prepare_send_message_handle, allowing more of the caller logic to be shared
  between OS platforms and simplifying handle ownership transfer.
- Rename set_owned_handle to receive_owned_message_handle
- Make receive_owned_message_handle a noop on message items that have
  no associated handles.  Simplifies caller logic by having handle
  deserialization only occur when message expects an associated handle.
  (This change is the core fix to the issue mentioned above.)

With this fix present, macOS AudioIPC is green on Try.