### PR TITLE
ipccore: Don't panic on wake() failures.

### DIFF
--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -127,7 +127,9 @@ impl EventLoopHandle {
     // Signal EventLoop to wake connection specified by `token` for processing.
     pub(crate) fn wake_connection(&self, token: Token) {
         if self.requests.push(Request::WakeConnection(token)).is_ok() {
-            self.waker.wake().expect("wake failed");
+            if let Err(e) = self.waker.wake() {
+                error!("wake_connection: waker.wake() failed: {e}");
+            }
         }
     }
 }


### PR DESCRIPTION
wake() can fail if the system is experiencing resource exhaustion, we see this as a [rare crash](https://crash-stats.mozilla.org/report/index/acbcaf1e-62a2-401b-945e-252660260212).  We can't do much in this case, but it's better to log and continue than crash.