### PR TITLE
Improve server-side data callback validation

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -235,7 +235,7 @@ impl ServerStreamCallbacks {
         }
 
         if self.input_frame_size != 0 {
-            if input.len() > self.shm.get_size() {
+            if input.is_empty() || input.len() > self.shm.get_size() {
                 debug!(
                     "bad input size: input={} shm={}",
                     input.len(),
@@ -251,7 +251,8 @@ impl ServerStreamCallbacks {
             }
         }
 
-        if self.output_frame_size != 0 && output.len() > self.shm.get_size() {
+        if self.output_frame_size != 0 && (output.is_empty() || output.len() > self.shm.get_size())
+        {
             debug!(
                 "bad output size: output={} shm={}",
                 output.len(),

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -276,6 +276,15 @@ impl ServerStreamCallbacks {
             Ok(CallbackResp::Data(frames)) => {
                 if frames >= 0 && self.output_frame_size != 0 {
                     let nbytes = frames as usize * self.output_frame_size as usize;
+                    if nbytes > output.len() || nbytes > self.shm.get_size() {
+                        debug!(
+                            "bad callback response: nbytes={} output={} shm={}",
+                            nbytes,
+                            output.len(),
+                            self.shm.get_size()
+                        );
+                        return cubeb::ffi::CUBEB_ERROR.try_into().unwrap();
+                    }
                     unsafe {
                         output[..nbytes].copy_from_slice(self.shm.get_slice(nbytes).unwrap());
                     }


### PR DESCRIPTION
This converts a few cases of panics into log + return error, protecting the server from crashing if the client is misbehaving.