### PR TITLE
ipccore: Make bind_server non-blocking.

### DIFF
--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -40,7 +40,7 @@ enum Request {
     AddConnection(
         sys::Pipe,
         Box<dyn Driver + Send>,
-        mpsc::Sender<Result<Token>>,
+        Option<mpsc::Sender<Result<Token>>>,
     ),
     // See EventLoop::shutdown
     Shutdown,
@@ -77,6 +77,10 @@ impl EventLoopHandle {
         })
     }
 
+    // Non-blocking server bind. The pipe pair is fully connected at creation,
+    // so the client can write immediately — data is buffered by the OS kernel
+    // until the event loop registers the server end. If registration fails,
+    // the server pipe is dropped and the client gets a broken-pipe error.
     pub fn bind_server<S: Server + Send + 'static>(
         &self,
         server: S,
@@ -88,13 +92,29 @@ impl EventLoopHandle {
     {
         let handler = make_server::<S>(server);
         let driver = Box::new(FramedDriver::new(handler));
-        let r = self.add_connection(connection, driver);
+        let r = self.add_connection_async(connection, driver);
         trace!("EventLoop::bind_server {r:?}");
-        r.map(|_| ())
+        r
     }
 
-    // Register a new connection with associated driver on the EventLoop.
-    // TODO: Since this is called from a Gecko main thread, make this non-blocking wrt. the EventLoop.
+    // Fire-and-forget connection registration. Returns immediately without
+    // waiting for the event loop to process the request.
+    fn add_connection_async(
+        &self,
+        connection: sys::Pipe,
+        driver: Box<dyn Driver + Send>,
+    ) -> Result<()> {
+        assert_not_in_event_loop_thread();
+        self.requests
+            .push(Request::AddConnection(connection, driver, None))
+            .map_err(|_| {
+                debug!("EventLoopHandle::add_connection_async send failed");
+                io::ErrorKind::ConnectionAborted
+            })?;
+        self.waker.wake()
+    }
+
+    // Register a new connection, blocking until the event loop acknowledges it.
     fn add_connection(
         &self,
         connection: sys::Pipe,
@@ -103,7 +123,7 @@ impl EventLoopHandle {
         assert_not_in_event_loop_thread();
         let (tx, rx) = mpsc::channel();
         self.requests
-            .push(Request::AddConnection(connection, driver, tx))
+            .push(Request::AddConnection(connection, driver, Some(tx)))
             .map_err(|_| {
                 debug!("EventLoopHandle::add_connection send failed");
                 io::ErrorKind::ConnectionAborted
@@ -249,7 +269,14 @@ impl EventLoop {
                 Request::AddConnection(pipe, driver, tx) => {
                     debug!("{}: EventLoop: handling add_connection", self.name);
                     let r = self.add_connection(pipe, driver);
-                    tx.send(r).expect("EventLoop::add_connection");
+                    if let Some(tx) = tx {
+                        tx.send(r).expect("EventLoop::add_connection");
+                    } else if let Err(e) = r {
+                        debug!(
+                            "{}: EventLoop: async add_connection failed: {:?}",
+                            self.name, e
+                        );
+                    }
                 }
                 Request::Shutdown => {
                     debug!("{}: EventLoop: handling shutdown", self.name);
@@ -914,5 +941,147 @@ mod test {
         drop(elt);
 
         stop_rx.recv().expect("before_stop callback done");
+    }
+
+    // Verify client can send before the server event loop processes the
+    // async AddConnection request. Data is buffered by the OS kernel.
+    #[test]
+    fn async_bind_server() {
+        init();
+
+        // Gate the server event loop: it blocks in after_start until we release it.
+        let (gate_tx, gate_rx) = mpsc::channel();
+        let server = EventLoopThread::new(
+            "test-server".to_string(),
+            None,
+            move || {
+                gate_rx.recv().ok();
+            },
+            || {},
+        )
+        .expect("server EventLoopThread");
+        let server_handle = server.handle();
+
+        let (server_pipe, client_pipe) = sys::make_pipe_pair().expect("make_pipe_pair");
+        server_handle
+            .bind_server(TestServerImpl {}, server_pipe)
+            .expect("bind_server");
+
+        // Client setup — bind_client is synchronous and uses its own event loop.
+        let client = EventLoopThread::new("test-client".to_string(), None, || {}, || {})
+            .expect("client EventLoopThread");
+        let client_handle = client.handle();
+        let client_pipe = unsafe { sys::Pipe::from_raw_handle(client_pipe) };
+        let client_proxy = client_handle
+            .bind_client::<TestClientImpl>(client_pipe)
+            .expect("client bind_client");
+
+        // Spawn call() on a background thread — it blocks waiting for
+        // the response, which can't arrive until the gate is released.
+        let call_thread = thread::spawn(move || client_proxy.call(TestServerMessage::TestRequest));
+
+        // Wait for the client event loop to serialize the request and
+        // write it to the pipe.  The client event loop is running
+        // freely and should flush within microseconds; 200ms is a
+        // generous margin.  There is no portable, non-intrusive way
+        // to observe the write without racing mio's registration.
+        thread::sleep(std::time::Duration::from_millis(200));
+
+        // Release the server gate.  The server event loop now processes
+        // AddConnection (registering the pipe with mio) and immediately
+        // sees the buffered client data as a readability event.
+        gate_tx.send(()).ok();
+
+        let response = call_thread
+            .join()
+            .expect("call thread panicked")
+            .expect("client response");
+        assert_eq!(response, TestClientMessage::TestResponse);
+
+        drop(client);
+        drop(server);
+    }
+
+    // Verify that dropping the server before processing the async
+    // AddConnection propagates as a transport error to the client.
+    #[test]
+    fn async_bind_server_drops_before_processing() {
+        init();
+        let server = EventLoopThread::new("test-server".to_string(), None, || {}, || {})
+            .expect("server EventLoopThread");
+        let server_handle = server.handle();
+
+        let (server_pipe, client_pipe) = sys::make_pipe_pair().expect("make_pipe_pair");
+        server_handle
+            .bind_server(TestServerImpl {}, server_pipe)
+            .expect("bind_server");
+
+        // Drop the server immediately — queued AddConnection may not be processed.
+        drop(server);
+
+        let client = EventLoopThread::new("test-client".to_string(), None, || {}, || {})
+            .expect("client EventLoopThread");
+        let client_handle = client.handle();
+
+        let client_pipe = unsafe { sys::Pipe::from_raw_handle(client_pipe) };
+        let client_proxy = client_handle
+            .bind_client::<TestClientImpl>(client_pipe)
+            .expect("client bind_client");
+
+        let response = client_proxy.call(TestServerMessage::TestRequest);
+        response.expect_err("server dropped, should get transport error");
+
+        drop(client);
+    }
+
+    // Verify that an async AddConnection that is never processed
+    // (server shuts down before reaching it in the queue) propagates
+    // as a transport error to the client.
+    #[test]
+    fn async_bind_server_never_processed() {
+        init();
+
+        // Gate the server event loop so we can control the order of
+        // requests in the queue.
+        let (gate_tx, gate_rx) = mpsc::channel();
+        let server = EventLoopThread::new(
+            "test-server".to_string(),
+            None,
+            move || {
+                gate_rx.recv().ok();
+            },
+            || {},
+        )
+        .expect("server EventLoopThread");
+        let server_handle = server.handle().clone();
+
+        // Queue Shutdown BEFORE AddConnection.  The event loop processes
+        // requests in FIFO order, so it will shut down without ever
+        // handling AddConnection.  The unprocessed server pipe is
+        // dropped with the queue, and the client sees a broken-pipe error.
+        server_handle.shutdown().expect("shutdown");
+
+        let (server_pipe, client_pipe) = sys::make_pipe_pair().expect("make_pipe_pair");
+        server_handle
+            .bind_server(TestServerImpl {}, server_pipe)
+            .expect("bind_server");
+
+        // Release gate — event loop runs, hits Shutdown first, exits.
+        gate_tx.send(()).ok();
+        drop(server);
+
+        let client = EventLoopThread::new("test-client".to_string(), None, || {}, || {})
+            .expect("client EventLoopThread");
+        let client_handle = client.handle();
+
+        let client_pipe = unsafe { sys::Pipe::from_raw_handle(client_pipe) };
+        let client_proxy = client_handle
+            .bind_client::<TestClientImpl>(client_pipe)
+            .expect("client bind_client");
+
+        let response = client_proxy.call(TestServerMessage::TestRequest);
+        response.expect_err("server never processed AddConnection, should get transport error");
+
+        drop(client);
     }
 }


### PR DESCRIPTION
We can rely on the underlying pipe to buffer data from the client and report errors if the pipe is disconnected, so we don't need to wait on the EventLoop to confirm server registration.

This allows audioipc2_server_new_client to be non-blocking, avoiding hanging the Gecko parent main thread if the AudioIPC server is not responding.