### PR TITLE
Simplify callback IPC message.

### DIFF
--- a/audioipc/src/messages.rs
+++ b/audioipc/src/messages.rs
@@ -147,6 +147,22 @@ impl From<&cubeb::StreamParamsRef> for StreamParams {
     }
 }
 
+impl StreamParams {
+    pub fn frame_size_in_bytes(&self) -> usize {
+        let format = self.format.into();
+        let sample_size = match format {
+            cubeb::SampleFormat::S16LE
+            | cubeb::SampleFormat::S16BE
+            | cubeb::SampleFormat::S16NE => 2usize,
+            cubeb::SampleFormat::Float32LE
+            | cubeb::SampleFormat::Float32BE
+            | cubeb::SampleFormat::Float32NE => 4usize,
+        };
+        let channel_count = self.channels as usize;
+        sample_size * channel_count
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StreamCreateParams {
     pub input_stream_params: Option<StreamParams>,
@@ -275,11 +291,7 @@ pub enum ClientMessage {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum CallbackReq {
-    Data {
-        nframes: isize,
-        input_frame_size: usize,
-        output_frame_size: usize,
-    },
+    Data { nframes: isize },
     State(ffi::cubeb_state),
     DeviceChange,
 }

--- a/client/src/stream.rs
+++ b/client/src/stream.rs
@@ -10,6 +10,7 @@ use audioipc::messages::{self, CallbackReq, CallbackResp, ClientMessage, ServerM
 use audioipc::shm::SharedMem;
 use audioipc::{rpccore, sys};
 use cubeb_backend::{ffi, DeviceRef, Error, InputProcessingParams, Result, Stream, StreamOps};
+use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_void;
 use std::ptr;
@@ -48,6 +49,8 @@ pub struct ClientStream<'ctx> {
 
 struct CallbackServer {
     shm: SharedMem,
+    input_frame_size: Option<usize>,
+    output_frame_size: Option<usize>,
     duplex_input: Option<Vec<u8>>,
     data_cb: ffi::cubeb_data_callback,
     state_cb: ffi::cubeb_state_callback,
@@ -63,17 +66,34 @@ impl rpccore::Server for CallbackServer {
 
     fn process(&mut self, req: Self::ServerMessage) -> Self::ClientMessage {
         match req {
-            CallbackReq::Data {
-                nframes,
-                input_frame_size,
-                output_frame_size,
-            } => {
+            CallbackReq::Data { nframes } => {
+                let Ok(nframes) = usize::try_from(nframes) else {
+                    warn!("stream_thread: Data Callback: invalid nframes={nframes}");
+                    return CallbackResp::Error(ffi::CUBEB_ERROR);
+                };
+
+                let input_frame_size = self.input_frame_size.unwrap_or(0);
+                let output_frame_size = self.output_frame_size.unwrap_or(0);
+                let shm_size = self.shm.get_size();
                 trace!(
                     "stream_thread: Data Callback: nframes={nframes} input_fs={input_frame_size} output_fs={output_frame_size}",
                 );
 
-                let input_nbytes = nframes as usize * input_frame_size;
-                let output_nbytes = nframes as usize * output_frame_size;
+                let Some(input_nbytes) = nframes
+                    .checked_mul(input_frame_size)
+                    .filter(|&n| n <= shm_size)
+                else {
+                    warn!("stream_thread: Data Callback: invalid nframes={nframes} input_fs={input_frame_size} shm={}", shm_size);
+                    return CallbackResp::Error(ffi::CUBEB_ERROR);
+                };
+
+                let Some(output_nbytes) = nframes
+                    .checked_mul(output_frame_size)
+                    .filter(|&n| n <= shm_size)
+                else {
+                    warn!("stream_thread: Data Callback: invalid nframes={nframes} output_fs={output_frame_size} shm={}", shm_size);
+                    return CallbackResp::Error(ffi::CUBEB_ERROR);
+                };
 
                 // Input and output reuse the same shmem backing.  Unfortunately, cubeb's data_callback isn't
                 // specified in such a way that would require the callee to consume all of the input before
@@ -90,7 +110,7 @@ impl rpccore::Server for CallbackServer {
 
                 run_in_callback(|| {
                     let nframes = unsafe {
-                        let input_ptr = if input_frame_size > 0 {
+                        let input_ptr = if self.input_frame_size.is_some() {
                             if let Some(buf) = &mut self.duplex_input {
                                 buf.as_ptr()
                             } else {
@@ -99,7 +119,7 @@ impl rpccore::Server for CallbackServer {
                         } else {
                             ptr::null()
                         };
-                        let output_ptr = if output_frame_size > 0 {
+                        let output_ptr = if self.output_frame_size.is_some() {
                             self.shm.get_mut_slice(output_nbytes).unwrap().as_mut_ptr()
                         } else {
                             ptr::null_mut()
@@ -152,6 +172,14 @@ impl<'ctx> ClientStream<'ctx> {
         user_ptr: *mut c_void,
     ) -> Result<Stream> {
         assert_not_in_callback();
+        let input_frame_size = init_params
+            .input_stream_params
+            .as_ref()
+            .map(messages::StreamParams::frame_size_in_bytes);
+        let output_frame_size = init_params
+            .output_stream_params
+            .as_ref()
+            .map(messages::StreamParams::frame_size_in_bytes);
 
         let rpc = ctx.rpc();
         let create_params = StreamCreateParams {
@@ -209,6 +237,8 @@ impl<'ctx> ClientStream<'ctx> {
 
         let server = CallbackServer {
             shm,
+            input_frame_size,
+            output_frame_size,
             duplex_input,
             data_cb: data_callback,
             state_cb: state_callback,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -16,7 +16,7 @@ use audioipc::{ipccore, rpccore, sys, PlatformHandle};
 use cubeb::InputProcessingParams;
 use cubeb_core as cubeb;
 use cubeb_core::ffi;
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use std::ffi::CStr;
 use std::mem::size_of;
 use std::os::raw::{c_int, c_long, c_void};
@@ -204,9 +204,9 @@ impl rpccore::Client for CallbackClient {
 
 struct ServerStreamCallbacks {
     /// Size of input frame in bytes
-    input_frame_size: u16,
+    input_frame_size: Option<usize>,
     /// Size of output frame in bytes
-    output_frame_size: u16,
+    output_frame_size: Option<usize>,
     /// Shared memory buffer for transporting audio data to/from client
     shm: SharedMem,
     /// RPC interface for data_callback (on OS audio thread) to server callback thread
@@ -234,7 +234,7 @@ impl ServerStreamCallbacks {
             return cubeb::ffi::CUBEB_ERROR.try_into().unwrap();
         }
 
-        if self.input_frame_size != 0 {
+        if self.input_frame_size.is_some() {
             if input.len() > self.shm.get_size() {
                 debug!(
                     "bad input size: input={} shm={}",
@@ -251,7 +251,8 @@ impl ServerStreamCallbacks {
             }
         }
 
-        if self.output_frame_size != 0 && (output.is_empty() || output.len() > self.shm.get_size())
+        if self.output_frame_size.is_some()
+            && (output.is_empty() || output.len() > self.shm.get_size())
         {
             debug!(
                 "bad output size: output={} shm={}",
@@ -266,16 +267,16 @@ impl ServerStreamCallbacks {
             return 0;
         }
 
-        let r = self.data_callback_rpc.call(CallbackReq::Data {
-            nframes,
-            input_frame_size: self.input_frame_size as usize,
-            output_frame_size: self.output_frame_size as usize,
-        });
+        let r = self.data_callback_rpc.call(CallbackReq::Data { nframes });
 
         match r {
             Ok(CallbackResp::Data(frames)) => {
-                if frames >= 0 && self.output_frame_size != 0 {
-                    let nbytes = frames as usize * self.output_frame_size as usize;
+                if let (Ok(frames), Some(output_frame_size)) =
+                    (usize::try_from(frames), self.output_frame_size)
+                {
+                    let Some(nbytes) = frames.checked_mul(output_frame_size) else {
+                        return cubeb::ffi::CUBEB_ERROR.try_into().unwrap();
+                    };
                     if nbytes > output.len() || nbytes > self.shm.get_size() {
                         debug!(
                             "bad callback response: nbytes={} output={} shm={}",
@@ -713,34 +714,24 @@ impl CubebServer {
 
     // Stream create is special, so it's been separated from process_msg.
     fn process_stream_create(&mut self, params: &StreamCreateParams) -> Result<ClientMessage> {
-        fn frame_size_in_bytes(params: Option<&StreamParams>) -> u16 {
-            params
-                .map(|p| {
-                    let format = p.format.into();
-                    let sample_size = match format {
-                        cubeb::SampleFormat::S16LE
-                        | cubeb::SampleFormat::S16BE
-                        | cubeb::SampleFormat::S16NE => 2,
-                        cubeb::SampleFormat::Float32LE
-                        | cubeb::SampleFormat::Float32BE
-                        | cubeb::SampleFormat::Float32NE => 4,
-                    };
-                    let channel_count = p.channels as u16;
-                    sample_size * channel_count
-                })
-                .unwrap_or(0u16)
-        }
-
         // Create the callback handling struct which is attached the cubeb stream.
-        let input_frame_size = frame_size_in_bytes(params.input_stream_params.as_ref());
-        let output_frame_size = frame_size_in_bytes(params.output_stream_params.as_ref());
+        let input_frame_size = params
+            .input_stream_params
+            .as_ref()
+            .map(StreamParams::frame_size_in_bytes);
+        let output_frame_size = params
+            .output_stream_params
+            .as_ref()
+            .map(StreamParams::frame_size_in_bytes);
 
         // Estimate a safe shmem size for this stream configuration.  If the server was configured with a fixed
         // shm_area_size override, use that instead.
         // TODO: Add a new cubeb API to query the precise buffer size required for a given stream config.
         // https://github.com/mozilla/audioipc-2/issues/124
         let shm_area_size = if self.shm_area_size == 0 {
-            let frame_size = output_frame_size.max(input_frame_size) as u32;
+            let in_fs = input_frame_size.unwrap_or(0);
+            let out_fs = output_frame_size.unwrap_or(0);
+            let frame_size = out_fs.max(in_fs) as u32;
             let in_rate = params.input_stream_params.map(|p| p.rate).unwrap_or(0);
             let out_rate = params.output_stream_params.map(|p| p.rate).unwrap_or(0);
             let rate = out_rate.max(in_rate);
@@ -888,13 +879,13 @@ unsafe extern "C" fn data_cb_c(
         let input = if input_buffer.is_null() {
             &[]
         } else {
-            let nbytes = nframes * c_long::from(cbs.input_frame_size);
+            let nbytes = nframes * cbs.input_frame_size.unwrap_or(0) as c_long;
             slice::from_raw_parts(input_buffer as *const u8, nbytes as usize)
         };
         let output: &mut [u8] = if output_buffer.is_null() {
             &mut []
         } else {
-            let nbytes = nframes * c_long::from(cbs.output_frame_size);
+            let nbytes = nframes * cbs.output_frame_size.unwrap_or(0) as c_long;
             slice::from_raw_parts_mut(output_buffer as *mut u8, nbytes as usize)
         };
         cbs.data_callback(input, output, nframes as isize) as c_long


### PR DESCRIPTION
Both server and client know the frame sizes, so there's no need to include them in every callback IPC message.