### PR TITLE
Validate target pid matches trusted client pid when promoting threads on Linux

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -30,7 +30,7 @@ memmap2 = "0.9"
 arrayvec = "0.7"
 
 [target.'cfg(target_os = "linux")'.dependencies.audio_thread_priority]
-version = "0.34"
+version = "0.35"
 default-features = false
 
 [target.'cfg(windows)'.dependencies]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,4 +13,4 @@ edition = "2018"
 audioipc = { package = "audioipc2", path = "../audioipc" }
 cubeb-backend = "0.32"
 log = "0.4"
-audio_thread_priority = { version = "0.34", default-features = false }
+audio_thread_priority = { version = "0.35", default-features = false }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,5 +15,5 @@ cubeb-core = "0.32"
 once_cell = "1.2.0"
 log = "0.4"
 slab = "0.4"
-audio_thread_priority = { version = "0.34", default-features = false }
+audio_thread_priority = { version = "0.35", default-features = false }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -677,12 +677,20 @@ impl CubebServer {
             #[cfg(target_os = "linux")]
             ServerMessage::PromoteThreadToRealTime(thread_info) => {
                 let info = RtPriorityThreadInfo::deserialize(thread_info);
-                match promote_thread_to_real_time(info, 0, 48000) {
-                    Ok(_) => {
-                        info!("Promotion of content process thread to real-time OK");
-                    }
-                    Err(_) => {
-                        warn!("Promotion of content process thread to real-time error");
+                if info.pid() as u32 != self.remote_pid.unwrap() {
+                    warn!(
+                        "PromoteThreadToRealTime: client supplied pid {} doesn't match trusted pid {}",
+                        info.pid(),
+                        self.remote_pid.unwrap()
+                    );
+                } else {
+                    match promote_thread_to_real_time(info, 0, 48000) {
+                        Ok(_) => {
+                            info!("Promotion of content process thread to real-time OK");
+                        }
+                        Err(_) => {
+                            warn!("Promotion of content process thread to real-time error");
+                        }
                     }
                 }
                 ClientMessage::ThreadPromoted


### PR DESCRIPTION
When promoting threads on Linux, verify the target pid supplied by the client matches the trusted pid supplied by Gecko during client setup via audioipc2_server_new_client.

Based on https://github.com/mozilla/audioipc/pull/190

Depends on https://github.com/mozilla/audio_thread_priority/pull/41 ~so fails to build on CI until I update audio_thread_priority~.