### PR TITLE
Validate cubeb stream params in audioipc-server

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -787,6 +787,26 @@ impl CubebServer {
         stm_tok: usize,
         params: &StreamInitParams,
     ) -> Result<ClientMessage> {
+        fn valid_stream_params(p: &StreamParams) -> bool {
+            const MAX_CHANNELS: u32 = 64;
+            const MIN_RATE: u32 = 1_000;
+            const MAX_RATE: u32 = 768_000;
+            p.channels >= 1
+                && p.channels <= MAX_CHANNELS
+                && p.rate >= MIN_RATE
+                && p.rate <= MAX_RATE
+        }
+        for p in params
+            .input_stream_params
+            .iter()
+            .chain(params.output_stream_params.iter())
+        {
+            if !valid_stream_params(p) {
+                self.streams.remove(stm_tok);
+                return Err(cubeb::Error::InvalidParameter.into());
+            }
+        }
+
         // Create cubeb stream from params
         let stream_name = params
             .stream_name


### PR DESCRIPTION
Reject channels outside [1, 64] or rates outside [1000, 768000] in process_stream_init to catch invalid params early.